### PR TITLE
Pass search text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,3 @@ fastlane/test_output
 
 .DS_Store
 Constants.swift
-Info.plist

--- a/GetFed/GetFed/Controllers/FoodSearchViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodSearchViewController.swift
@@ -12,6 +12,7 @@ class FoodSearchViewController: UIViewController {
 
     // MARK - Properties
     
+    var searchController: UISearchController!
     let apiClient = APIClient()
     let appId = EdamamAppID
     let appKey = EdamamAppKey
@@ -38,15 +39,15 @@ class FoodSearchViewController: UIViewController {
 extension FoodSearchViewController: UISearchBarDelegate {
     
     func setupSearchBar() {
-        let searchController = UISearchController(searchResultsController: nil)
+        searchController = UISearchController(searchResultsController: nil)
         navigationItem.searchController = searchController
         searchController.searchBar.delegate = self
         navigationItem.hidesSearchBarWhenScrolling = false
     }
     
     func getSearchText() -> String? {
-        let searchBar = navigationItem.searchController?.searchBar
-        let searchText = searchBar?.text
+        let searchBar = searchController.searchBar
+        let searchText = searchBar.text
         return searchText
     }
     

--- a/GetFed/GetFed/Controllers/FoodSearchViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodSearchViewController.swift
@@ -21,11 +21,13 @@ class FoodSearchViewController: UIViewController {
     // MARK - Lifecylce
     
     override func viewDidLoad() {
+        super.viewDidLoad()
         setupSearchBar()
         makeRequest(with: URL(string: "[redacted]")!)
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = false
     }
     
@@ -35,6 +37,12 @@ class FoodSearchViewController: UIViewController {
         let searchController = UISearchController(searchResultsController: nil)
         navigationItem.searchController = searchController
         navigationItem.hidesSearchBarWhenScrolling = false
+    }
+    
+    func getSearchText() -> String? {
+        let searchBar = navigationItem.searchController?.searchBar
+        let searchText = searchBar?.text
+        return searchText
     }
     
 }

--- a/GetFed/GetFed/Controllers/FoodSearchViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodSearchViewController.swift
@@ -9,10 +9,9 @@
 import UIKit
 
 class FoodSearchViewController: UIViewController {
-    
-    
-    
+
     // MARK - Properties
+    
     let apiClient = APIClient()
     let appId = EdamamAppID
     let appKey = EdamamAppKey
@@ -20,36 +19,28 @@ class FoodSearchViewController: UIViewController {
     var text = ""
     var searchResults: SearchResults?
     
-    // MARK - Lifecylce
+    // MARK - Lifecycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        //tableView.dataSource = self
-        //filteredData = data
         setupSearchBar()
         definesPresentationContext = true
-        //makeRequest(with: URL(string: "[redacted]")!)
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.isNavigationBarHidden = false
     }
-    
-    // MARK - Methods
- 
 }
 
 // MARK - UISearchBarDelegate Protocol Implementation
 
-extension FoodSearchViewController: UISearchBarDelegate /*, UISearchResultsUpdating*/ {
+extension FoodSearchViewController: UISearchBarDelegate {
     
     func setupSearchBar() {
         let searchController = UISearchController(searchResultsController: nil)
         navigationItem.searchController = searchController
-       // searchController.searchResultsUpdater = self
         searchController.searchBar.delegate = self
-        //searchController.definesPresentationContext = true
         navigationItem.hidesSearchBarWhenScrolling = false
     }
     
@@ -58,6 +49,7 @@ extension FoodSearchViewController: UISearchBarDelegate /*, UISearchResultsUpdat
         let searchText = searchBar?.text
         return searchText
     }
+    
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         print("👍 pressed")
         if let text = searchBar.text {
@@ -86,9 +78,7 @@ extension FoodSearchViewController {
     }
     
     func makeRequest(with url: URL) {
-        //guard let text = navigationItem.searchController?.searchBar.text else { return }
         apiClient.fetchData(url: url) { (results: SearchResults) in
-            //load data into searchResults
             self.searchResults = results
             print(results)
         }

--- a/GetFed/GetFed/Controllers/FoodSearchViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodSearchViewController.swift
@@ -10,6 +10,8 @@ import UIKit
 
 class FoodSearchViewController: UIViewController {
     
+    
+    
     // MARK - Properties
     let apiClient = APIClient()
     let appId = EdamamAppID
@@ -22,8 +24,11 @@ class FoodSearchViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        //tableView.dataSource = self
+        //filteredData = data
         setupSearchBar()
-        makeRequest(with: URL(string: "[redacted]")!)
+        definesPresentationContext = true
+        //makeRequest(with: URL(string: "[redacted]")!)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -32,10 +37,19 @@ class FoodSearchViewController: UIViewController {
     }
     
     // MARK - Methods
+ 
+}
+
+// MARK - UISearchBarDelegate Protocol Implementation
+
+extension FoodSearchViewController: UISearchBarDelegate /*, UISearchResultsUpdating*/ {
     
     func setupSearchBar() {
         let searchController = UISearchController(searchResultsController: nil)
         navigationItem.searchController = searchController
+       // searchController.searchResultsUpdater = self
+        searchController.searchBar.delegate = self
+        //searchController.definesPresentationContext = true
         navigationItem.hidesSearchBarWhenScrolling = false
     }
     
@@ -44,7 +58,21 @@ class FoodSearchViewController: UIViewController {
         let searchText = searchBar?.text
         return searchText
     }
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        print("👍 pressed")
+        if let text = searchBar.text {
+            print("Text: \(text)")
+            if let url = setURL(with: text) {
+                makeRequest(with: url)
+            }
+        } else {
+            print("No text")
+        }
+    }
     
+    func updateSearchResults(for searchController: UISearchController) {
+        //
+    }
 }
 // MARK - API Request
 
@@ -58,7 +86,7 @@ extension FoodSearchViewController {
     }
     
     func makeRequest(with url: URL) {
-        guard let text = navigationItem.searchController?.searchBar.text else { return }
+        //guard let text = navigationItem.searchController?.searchBar.text else { return }
         apiClient.fetchData(url: url) { (results: SearchResults) in
             //load data into searchResults
             self.searchResults = results

--- a/GetFed/GetFed/Controllers/FoodSearchViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodSearchViewController.swift
@@ -54,12 +54,15 @@ extension FoodSearchViewController: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         print("👍 pressed")
         if let text = searchBar.text {
-            print("Text: \(text)")
-            if let url = setURL(with: text) {
-                makeRequest(with: url)
+            if !text.isEmpty {
+                print("Text: \(text)")
+                if let url = setURL(with: text) {
+                    makeRequest(with: url)
+                }
+            } else {
+                print("No text")
+                //TODO: alert "please enter text"
             }
-        } else {
-            print("No text")
         }
     }
     

--- a/GetFed/GetFed/Models/Food.swift
+++ b/GetFed/GetFed/Models/Food.swift
@@ -48,17 +48,17 @@ struct Food: Decodable {
 }
 
 struct Nutrients: Decodable {
-    let calories: Double
+    let calories: Double?
     let protein: Double?
     let fat: Double?
-    let carbs: Double
+    let carbs: Double?
     
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: NutrientsCodingKeys.self)
-        calories = try container.decode(Double.self, forKey: .calories)
+        calories = try container.decodeIfPresent(Double.self, forKey: .calories)
         protein = try container.decodeIfPresent(Double.self, forKey: .protein)
         fat = try container.decodeIfPresent(Double.self, forKey: .fat)
-        carbs = try container.decode(Double.self, forKey: .carbs)
+        carbs = try container.decodeIfPresent(Double.self, forKey: .carbs)
     }
     
     enum NutrientsCodingKeys: String, CodingKey {


### PR DESCRIPTION
## What you did :question:
- Added ability for text entered in search bar to be used in the API request
- In model, accounted for all 'Nutrients' properties not being guaranteed

## How you did it :white_check_mark:
- Set search bar `delegate` to self
- Implemented `searchBarSearchButtonClicked` protocol method, which passes `searchBar.text` to the `setURL`, which creates a url that is passed to `makeRequest`


## How to test it :microscope:
- Run the app
- Tap 'Food Search'
- Enter any food ingredient into the search bar (ex: 'cracker')
- Note that the results are printed out to terminal (see screenshot)


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-11-21 at 12 34 37](https://user-images.githubusercontent.com/8409475/48860628-68d9a380-ed8f-11e8-9d82-c4cf0c0c0a5e.png)
<img width="490" alt="screen shot 2018-11-21 at 12 34 58 pm" src="https://user-images.githubusercontent.com/8409475/48860636-71ca7500-ed8f-11e8-83c0-f7ed16948fc0.png">
