### PR TITLE
Reference Food.Nutrient property values directly

### DIFF
--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -19,9 +19,6 @@ class FoodDetailViewController: UIViewController {
     
     // MARK - Properties
     var food: Food?
-    var protein: Double?
-    var carbs: Double?
-    var fat: Double?
     
     // MARK - Lifecycle
     override func viewDidLoad() {
@@ -32,7 +29,7 @@ class FoodDetailViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.navigationController?.isNavigationBarHidden = false
+        navigationController?.isNavigationBarHidden = false
     }
 
     // MARK - Methods
@@ -57,34 +54,12 @@ class FoodDetailViewController: UIViewController {
             } else {
                 caloriesLabel.text = "No calorie data"
             }
-            
-            if let protein = nutrients.protein {
-                self.protein = protein
-                print("Protein: \(self.protein!)")
-            } else {
-                self.protein = nil
-            }
-            
-            if let carbs = nutrients.carbs {
-                self.carbs = carbs
-                print("Carbs: \(self.carbs!)")
-            } else {
-                self.carbs = nil
-            }
-            
-            if let fat = nutrients.fat {
-                self.fat = fat
-                print("Fat: \(self.fat!)")
-            } else {
-                self.fat = nil
-            }
         } else {
             foodNameLabel.text = "No food data"
             brandNameLabel.isHidden = true
             caloriesLabel.isHidden = true
         }
     }
-
 }
 
 // MARK - Pie Chart Methods
@@ -97,17 +72,19 @@ extension FoodDetailViewController {
     }
     
     func populateMacroNutrientChartData() -> PieChartDataSet? {
-        guard let proteinData = self.protein else {
+        guard let food = food else { return nil }
+        
+        guard let proteinData = food.nutrients.protein else {
             print("No protein data")
             return nil
         }
         
-        guard let carbsData = self.carbs else {
+        guard let carbsData = food.nutrients.carbs else {
             print("No carbs data")
             return nil
         }
         
-        guard let fatData = self.fat else {
+        guard let fatData = food.nutrients.fat else {
             print("No fat data")
             return nil
         }


### PR DESCRIPTION
## What you did :question:
- Removed the logic that copied Food object property values by accessing them directly

## How you did it :white_check_mark:
- Referenced the passed Food.Nutrient property values 'protein', 'carbs' and 'fat' in `populateMacroNutrientChartData` when unwrapping them as values to be passed into PieChartDataEntry


## How to test it :microscope:
- Run the app
- Tap 'Food Search'
- Search for 'brownies'
- Tap on the cell that reads 'Brownies' and 'Cold Stone Creamery'
- Note that the Food Detail View displays an animated pie chart with macronutrient data (protein, carbs, and fat) shown


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-11-29 at 16 13 21](https://user-images.githubusercontent.com/8409475/49252747-d79fa800-f3f2-11e8-990e-91c15f91bb02.png)
