### PR TITLE
Add color assets

### DIFF
--- a/GetFed/GetFed.xcodeproj/project.pbxproj
+++ b/GetFed/GetFed.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0663B1C821AC8F58000B2754 /* FoodDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0663B1C721AC8F58000B2754 /* FoodDetailViewController.swift */; };
 		06FF832121AEF3810066424C /* CustomColorTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF832021AEF3810066424C /* CustomColorTemplate.swift */; };
 		06FF832321AEF8430066424C /* CustomValueFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF832221AEF8420066424C /* CustomValueFormatter.swift */; };
+		06FF832521B1981D0066424C /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06FF832421B1981D0066424C /* Colors.xcassets */; };
 		4EBFAFE8A5DF71DB25281C1F /* Pods_GetFed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B47EB7B8A39DA18E491DD2D1 /* Pods_GetFed.framework */; };
 /* End PBXBuildFile section */
 
@@ -43,6 +44,7 @@
 		0663B1C721AC8F58000B2754 /* FoodDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodDetailViewController.swift; sourceTree = "<group>"; };
 		06FF832021AEF3810066424C /* CustomColorTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomColorTemplate.swift; sourceTree = "<group>"; };
 		06FF832221AEF8420066424C /* CustomValueFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomValueFormatter.swift; sourceTree = "<group>"; };
+		06FF832421B1981D0066424C /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		27E1F1A676CD7A4435C6EB69 /* Pods-GetFed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetFed.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GetFed/Pods-GetFed.debug.xcconfig"; sourceTree = "<group>"; };
 		B47EB7B8A39DA18E491DD2D1 /* Pods_GetFed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetFed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF8590CD873BED214503BF2 /* Pods-GetFed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetFed.release.xcconfig"; path = "Pods/Target Support Files/Pods-GetFed/Pods-GetFed.release.xcconfig"; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 				0663B1A3219F4970000B2754 /* Assets.xcassets */,
 				0663B1A5219F4970000B2754 /* LaunchScreen.storyboard */,
 				0663B1A8219F4970000B2754 /* Info.plist */,
+				06FF832421B1981D0066424C /* Colors.xcassets */,
 			);
 			path = GetFed;
 			sourceTree = "<group>";
@@ -210,6 +213,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06FF832521B1981D0066424C /* Colors.xcassets in Resources */,
 				0663B1A7219F4970000B2754 /* LaunchScreen.storyboard in Resources */,
 				0663B1A4219F4970000B2754 /* Assets.xcassets in Resources */,
 				0663B1C621A63000000B2754 /* FoodResultTableViewCell.xib in Resources */,

--- a/GetFed/GetFed/Colors.xcassets/CarbsColor.colorset/Contents.json
+++ b/GetFed/GetFed/Colors.xcassets/CarbsColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.010",
+          "alpha" : "1.000",
+          "blue" : "0.730",
+          "green" : "0.990"
+        }
+      }
+    }
+  ]
+}

--- a/GetFed/GetFed/Colors.xcassets/Contents.json
+++ b/GetFed/GetFed/Colors.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/GetFed/GetFed/Colors.xcassets/FatColor.colorset/Contents.json
+++ b/GetFed/GetFed/Colors.xcassets/FatColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.910",
+          "alpha" : "1.000",
+          "blue" : "0.360",
+          "green" : "0.890"
+        }
+      }
+    }
+  ]
+}

--- a/GetFed/GetFed/Colors.xcassets/ProteinColor.colorset/Contents.json
+++ b/GetFed/GetFed/Colors.xcassets/ProteinColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.750",
+          "alpha" : "1.000",
+          "blue" : "0.920",
+          "green" : "0.840"
+        }
+      }
+    }
+  ]
+}

--- a/GetFed/GetFed/Helpers/CustomColorTemplate.swift
+++ b/GetFed/GetFed/Helpers/CustomColorTemplate.swift
@@ -1,5 +1,5 @@
 //
-//  ColorTemplate.swift
+//  CustomColorTemplate.swift
 //  GetFed
 //
 //  Created by Britney Smith on 11/28/18.

--- a/GetFed/GetFed/Helpers/CustomColorTemplate.swift
+++ b/GetFed/GetFed/Helpers/CustomColorTemplate.swift
@@ -13,10 +13,13 @@ import Charts
 extension ChartColorTemplates {
     
     public class func customTemplateBright() -> [UIColor] {
-        return [
-            UIColor(red:0.75, green:0.84, blue:0.92, alpha:1.0) /* pale lavender */,
-            UIColor(red:0.01, green:0.99, blue:0.73, alpha:1.0) /* aqua */,
-            UIColor(red:0.91, green:0.89, blue:0.36, alpha:1.0) /* pale yellow */
-        ]
+        guard let proteinColor = UIColor(named: "ProteinColor"),
+              let carbsColor = UIColor(named: "CarbsColor"),
+              let fatColor = UIColor(named: "FatColor")
+            else {
+                    print("No colors!")
+                    return []
+                 }
+        return [proteinColor, carbsColor, fatColor]
     }
 }


### PR DESCRIPTION
## What you did :question:
- Uses named colors in ChartColorTemplates instead of UIColor rgb color types

## How you did it :white_check_mark:
- Created Colors.xcassets folder
- Added colors for 'protein', 'carbs' and 'fat' as color sets to the Colors.xcassets folder
- Replaced the UIColor rgb types returned in array at `customTemplateBright` to UIColor(named:) types

## How to test it :microscope:
- Run the app
- Tap 'Food Search'
- Search for 'Brownie'
- Tap the cell that reads 'Brownie' and 'Marie Callendar's'
- The colors of the pie chart displaying the macronutrients should match the screenshot below


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-11-30 at 11 29 49](https://user-images.githubusercontent.com/8409475/49302184-5a2c7400-f494-11e8-9fd5-43d677ca9193.png)
