### PR TITLE
Chart style

### DIFF
--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -113,14 +113,37 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="48" width="315" height="0.0"/>
+                                        <rect key="frame" x="30" y="48" width="315" height="513.5"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
+                                        <rect key="frame" x="61.5" y="561.5" width="252" height="20.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
+                                                <rect key="frame" x="0.0" y="0.0" width="95.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
+                                                <rect key="frame" x="100.5" y="0.0" width="84.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
+                                                <rect key="frame" x="190" y="0.0" width="62" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="48" width="142" height="555"/>
+                                        <rect key="frame" x="116.5" y="582" width="142" height="21"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -146,8 +169,11 @@
                     <connections>
                         <outlet property="brandNameLabel" destination="hW6-qa-hZr" id="eQG-nx-ffQ"/>
                         <outlet property="caloriesLabel" destination="hJc-Io-5qD" id="Hgk-at-2TE"/>
+                        <outlet property="carbsLabel" destination="xgo-Yg-tdL" id="CFi-Du-7xa"/>
+                        <outlet property="fatLabel" destination="n6g-er-nys" id="5cO-r9-FQ3"/>
                         <outlet property="foodNameLabel" destination="jXi-uR-aoY" id="cSO-tI-Xdd"/>
                         <outlet property="macroNutrientChart" destination="aDn-XM-Q4W" id="Axw-OT-DPv"/>
+                        <outlet property="proteinLabel" destination="Cf6-t2-S3O" id="odm-ma-Zvf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="t5Z-hq-KYj" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -113,31 +114,31 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="48" width="315" height="513.5"/>
+                                        <rect key="frame" x="30" y="48" width="315" height="476.5"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="61.5" y="561.5" width="252" height="20.5"/>
+                                        <rect key="frame" x="50" y="524.5" width="275" height="57.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="0.0" width="95.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
+                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="57.5"/>
+                                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
+                                                <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="100.5" y="0.0" width="84.5" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
+                                                <rect key="frame" x="5" y="0.0" width="79" height="57.5"/>
+                                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
+                                                <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="190" y="0.0" width="62" height="20.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
+                                                <rect key="frame" x="89" y="0.0" width="186" height="57.5"/>
+                                                <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
+                                                <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
@@ -150,6 +151,8 @@
                                     </label>
                                 </subviews>
                                 <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="Dga-vQ-3Df" secondAttribute="trailing" constant="50" id="74L-sp-kKo"/>
+                                    <constraint firstItem="Dga-vQ-3Df" firstAttribute="leading" secondItem="eCX-Cu-0gX" secondAttribute="leading" constant="50" id="DKt-Cu-KtZ"/>
                                     <constraint firstItem="jXi-uR-aoY" firstAttribute="top" secondItem="eCX-Cu-0gX" secondAttribute="top" constant="10" id="Qt7-3d-aAS"/>
                                     <constraint firstItem="aDn-XM-Q4W" firstAttribute="leading" secondItem="eCX-Cu-0gX" secondAttribute="leading" constant="30" id="tan-EH-oHE"/>
                                     <constraint firstAttribute="trailing" secondItem="aDn-XM-Q4W" secondAttribute="trailing" constant="30" id="z4L-wL-aoo"/>
@@ -199,4 +202,15 @@
             <point key="canvasLocation" x="-47.200000000000003" y="59.820089955022496"/>
         </scene>
     </scenes>
+    <resources>
+        <namedColor name="CarbsColor">
+            <color red="0.0099999997764825821" green="0.99000000953674316" blue="0.73000001907348633" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="FatColor">
+            <color red="0.9100000262260437" green="0.88999998569488525" blue="0.36000001430511475" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="ProteinColor">
+            <color red="0.75" green="0.8399999737739563" blue="0.92000001668930054" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -60,15 +60,15 @@ class FoodDetailViewController: UIViewController {
             }
             
             if let protein = nutrients.protein {
-                proteinLabel.text = "\(Int(protein)) g"
+                proteinLabel.text = "\(Int(protein))g"
             }
             
             if let carbs = nutrients.carbs {
-                carbsLabel.text = "\(Int(carbs)) g"
+                carbsLabel.text = "\(Int(carbs))g"
             }
             
             if let fat = nutrients.fat {
-                fatLabel.text = "\(Int(fat)) g"
+                fatLabel.text = "\(Int(fat))g"
             }
             
         } else {

--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -16,6 +16,10 @@ class FoodDetailViewController: UIViewController {
     @IBOutlet var caloriesLabel: UILabel!
     @IBOutlet var brandNameLabel: UILabel!
     @IBOutlet var macroNutrientChart: PieChartView!
+    @IBOutlet var proteinLabel: UILabel!
+    @IBOutlet var carbsLabel: UILabel!
+    @IBOutlet var fatLabel: UILabel!
+    
     
     // MARK - Properties
     var food: Food?
@@ -54,10 +58,26 @@ class FoodDetailViewController: UIViewController {
             } else {
                 caloriesLabel.text = "No calorie data"
             }
+            
+            if let protein = nutrients.protein {
+                proteinLabel.text = "\(Int(protein)) g"
+            }
+            
+            if let carbs = nutrients.carbs {
+                carbsLabel.text = "\(Int(carbs)) g"
+            }
+            
+            if let fat = nutrients.fat {
+                fatLabel.text = "\(Int(fat)) g"
+            }
+            
         } else {
             foodNameLabel.text = "No food data"
             brandNameLabel.isHidden = true
             caloriesLabel.isHidden = true
+            proteinLabel.isHidden = true
+            carbsLabel.isHidden = true
+            fatLabel.isHidden = true
         }
     }
 }
@@ -120,7 +140,7 @@ extension FoodDetailViewController {
         //macroNutrientChart.legend.enabled = false
         macroNutrientChart.legend.font = legendFont
         macroNutrientChart.legend.formSize = 20.0
-        macroNutrientChart.legend.orientation = .vertical
+        macroNutrientChart.legend.orientation = .horizontal
         
         if let dataSet = dataSet {
             let chartLabelColor = UIColor(red:0.38, green:0.07, blue:0.33, alpha:1.0)

--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -137,22 +137,20 @@ extension FoodDetailViewController {
         
         guard let legendFont = UIFont(name:"HelveticaNeue-Bold", size: 18.0) else { return }
         macroNutrientChart.animate(yAxisDuration: 0.9, easingOption: .easeInSine)
-        //macroNutrientChart.legend.enabled = false
         macroNutrientChart.legend.font = legendFont
         macroNutrientChart.legend.formSize = 20.0
         macroNutrientChart.legend.orientation = .horizontal
+        macroNutrientChart.legend.horizontalAlignment = .center
+        macroNutrientChart.drawEntryLabelsEnabled = false
         
         if let dataSet = dataSet {
             let chartLabelColor = UIColor(red:0.38, green:0.07, blue:0.33, alpha:1.0)
             guard let customFont = UIFont(name:"HelveticaNeue-Bold", size: 18.0) else { return }
+            dataSet.drawValuesEnabled = false
             dataSet.colors = ChartColorTemplates.customTemplateBright()
             dataSet.valueTextColor = chartLabelColor
             dataSet.valueFont = customFont
-            //dataSet.xValuePosition = .outsideSlice
-            //dataSet.yValuePosition = .outsideSlice
             dataSet.valueLineColor = chartLabelColor
-            //dataSet.valueLinePart1Length = 0.25
-            //dataSet.valueLinePart2Length = 0.1
         }
     }
 }

--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -94,7 +94,7 @@ extension FoodDetailViewController {
         let entryThree = PieChartDataEntry(value: fatData, label: "Fat")
         let dataEntries = [entryOne, entryTwo, entryThree]
         
-        let dataSet = PieChartDataSet(values: dataEntries, label: "samplechartlabel")
+        let dataSet = PieChartDataSet(values: dataEntries, label: "")
         let data = PieChartData(dataSet: dataSet)
         macroNutrientChart.data = data
         
@@ -115,8 +115,12 @@ extension FoodDetailViewController {
     
     func styleMacroNutrientChart(with dataSet: PieChartDataSet?) {
         
+        guard let legendFont = UIFont(name:"HelveticaNeue-Bold", size: 18.0) else { return }
         macroNutrientChart.animate(yAxisDuration: 0.9, easingOption: .easeInSine)
-        macroNutrientChart.legend.enabled = false
+        //macroNutrientChart.legend.enabled = false
+        macroNutrientChart.legend.font = legendFont
+        macroNutrientChart.legend.formSize = 20.0
+        macroNutrientChart.legend.orientation = .vertical
         
         if let dataSet = dataSet {
             let chartLabelColor = UIColor(red:0.38, green:0.07, blue:0.33, alpha:1.0)
@@ -124,11 +128,11 @@ extension FoodDetailViewController {
             dataSet.colors = ChartColorTemplates.customTemplateBright()
             dataSet.valueTextColor = chartLabelColor
             dataSet.valueFont = customFont
-            dataSet.xValuePosition = .outsideSlice
-            dataSet.yValuePosition = .outsideSlice
+            //dataSet.xValuePosition = .outsideSlice
+            //dataSet.yValuePosition = .outsideSlice
             dataSet.valueLineColor = chartLabelColor
-            dataSet.valueLinePart1Length = 0.45
-            dataSet.valueLinePart2Length = 0.1
+            //dataSet.valueLinePart1Length = 0.25
+            //dataSet.valueLinePart2Length = 0.1
         }
     }
 }


### PR DESCRIPTION
## What you did :question:
- Refactored Chart UI to prevent label collisions are labels displayed offscreen
- Displays macronutrient values in color-coded labels outside chart instead

## How you did it :white_check_mark:
- Created horizontal stack view with three color coded labels for 'protein', 'carbs', and 'fat' values (colors match those used in pie chart)
- Populated those labels after Food object was passed in segue
- Adjusted autolayout for labels
- Hid x- and y-axis labels in pie chart
- Centered pie chart legend


## How to test it :microscope:
- Run the app
- Tap 'Food Search'
- Search for 'Bread'
- Tap the cell that reads 'Bread, wheat'
- Note that the protein, carbs, and fat values are displayed outside of the pie chart, the label text colors match the legend, and the legend is centered (see screenshot)
- Note that the values are consistent with the values displayed in the terminal (see screenshot)


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-11-30 at 15 12 50](https://user-images.githubusercontent.com/8409475/49312897-9de2a600-f4b3-11e8-8697-72accfa8364e.png)
![screen shot 2018-11-30 at 3 20 34 pm](https://user-images.githubusercontent.com/8409475/49312919-beaafb80-f4b3-11e8-89c9-8866930a952e.png)

