### PR TITLE
Changed chart label to reflect serving size

### DIFF
--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -114,7 +114,7 @@ extension FoodDetailViewController {
         let entryThree = PieChartDataEntry(value: fatData, label: "Fat")
         let dataEntries = [entryOne, entryTwo, entryThree]
         
-        let dataSet = PieChartDataSet(values: dataEntries, label: "")
+        let dataSet = PieChartDataSet(values: dataEntries, label: "per 100 grams")
         let data = PieChartData(dataSet: dataSet)
         macroNutrientChart.data = data
         


### PR DESCRIPTION
## What you did :question:
- Added serving size info to Food Detail View

## How you did it :white_check_mark:
- Added string "per 100 grams" in the PieChartDataSet's 'label' property


## How to test it :microscope:
- Run the app
- Tap 'Food Search'
- Search for 'cookies'
- Tap the result that reads 'Fast foods, cookies, chocolate chip'
- Note that the label 'per 100 grams' is displayed below the pie chart legend

## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-12-03 at 09 36 53](https://user-images.githubusercontent.com/8409475/49380852-a66bf400-f6e0-11e8-94d2-1712856b4b32.png)
