### PR TITLE
Food entry

### DIFF
--- a/GetFed/GetFed.xcodeproj/project.pbxproj
+++ b/GetFed/GetFed.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		06FF832321AEF8430066424C /* CustomValueFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF832221AEF8420066424C /* CustomValueFormatter.swift */; };
 		06FF832521B1981D0066424C /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06FF832421B1981D0066424C /* Colors.xcassets */; };
 		06FF832821B6C1260066424C /* GetFed.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 06FF832621B6C1260066424C /* GetFed.xcdatamodeld */; };
+		06FF834B21B6D4010066424C /* FoodEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF834A21B6D4010066424C /* FoodEntryViewController.swift */; };
 		4EBFAFE8A5DF71DB25281C1F /* Pods_GetFed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B47EB7B8A39DA18E491DD2D1 /* Pods_GetFed.framework */; };
 /* End PBXBuildFile section */
 
@@ -47,6 +48,7 @@
 		06FF832221AEF8420066424C /* CustomValueFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomValueFormatter.swift; sourceTree = "<group>"; };
 		06FF832421B1981D0066424C /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		06FF832721B6C1260066424C /* GetFed.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = GetFed.xcdatamodel; sourceTree = "<group>"; };
+		06FF834A21B6D4010066424C /* FoodEntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodEntryViewController.swift; sourceTree = "<group>"; };
 		27E1F1A676CD7A4435C6EB69 /* Pods-GetFed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetFed.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GetFed/Pods-GetFed.debug.xcconfig"; sourceTree = "<group>"; };
 		B47EB7B8A39DA18E491DD2D1 /* Pods_GetFed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetFed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF8590CD873BED214503BF2 /* Pods-GetFed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetFed.release.xcconfig"; path = "Pods/Target Support Files/Pods-GetFed/Pods-GetFed.release.xcconfig"; sourceTree = "<group>"; };
@@ -123,6 +125,7 @@
 				0663B1B7219FC68C000B2754 /* HomeViewController.swift */,
 				0663B1BE21A339F6000B2754 /* FoodSearchViewController.swift */,
 				0663B1C721AC8F58000B2754 /* FoodDetailViewController.swift */,
+				06FF834A21B6D4010066424C /* FoodEntryViewController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -284,6 +287,7 @@
 				06FF832121AEF3810066424C /* CustomColorTemplate.swift in Sources */,
 				06FF832821B6C1260066424C /* GetFed.xcdatamodeld in Sources */,
 				0663B19D219F496E000B2754 /* AppDelegate.swift in Sources */,
+				06FF834B21B6D4010066424C /* FoodEntryViewController.swift in Sources */,
 				0663B1B5219F6A64000B2754 /* Identity.swift in Sources */,
 				0663B1C521A63000000B2754 /* FoodResultTableViewCell.swift in Sources */,
 				0663B1BF21A339F6000B2754 /* FoodSearchViewController.swift in Sources */,

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -112,7 +112,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
@@ -135,7 +135,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="brandTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
@@ -159,7 +159,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="proteinTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
@@ -183,7 +183,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="carbsTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
@@ -207,7 +207,7 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="fatTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
@@ -307,7 +307,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nts-7g-0EP" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1977" y="1127"/>
+            <point key="canvasLocation" x="1977" y="853"/>
         </scene>
         <!--Food Detail View Controller-->
         <scene sceneID="XbU-TW-66P">

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -118,7 +118,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;cookies&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
@@ -141,7 +141,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;Cookies Inc&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
@@ -165,7 +165,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;5&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
@@ -189,7 +189,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;35&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
@@ -213,7 +213,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;15&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -94,180 +94,186 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
-                                <rect key="frame" x="25" y="114" width="325" height="425"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mWU-tC-fcY">
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="365"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
+                                        <rect key="frame" x="50" y="50" width="168" height="425"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
+                                                <rect key="frame" x="0.0" y="0.0" width="168" height="365"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
-                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
-                                                        </constraints>
-                                                        <nil key="textColor"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
+                                                        <rect key="frame" x="0.0" y="0.0" width="168" height="61"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
+                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
+                                                                </constraints>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
+                                                        <rect key="frame" x="0.0" y="76" width="168" height="61"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
+                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
+                                                                </constraints>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
+                                                        <rect key="frame" x="0.0" y="152" width="168" height="61"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
+                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
+                                                                </constraints>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
+                                                        <rect key="frame" x="0.0" y="228" width="168" height="61"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
+                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
+                                                                </constraints>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
+                                                        <rect key="frame" x="0.0" y="304" width="168" height="61"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
+                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
+                                                                </constraints>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                        <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                                <rect key="frame" x="0.0" y="76" width="325" height="61"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="41W-1g-jcJ">
+                                                <rect key="frame" x="0.0" y="375" width="168" height="50"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
-                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aR0-VD-u1Y">
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="50"/>
+                                                        <color key="backgroundColor" red="1" green="0.0" blue="0.058155415100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
+                                                            <constraint firstAttribute="height" constant="50" id="V6M-5Y-lHq"/>
                                                         </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
-                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                        <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
+                                                        <state key="normal" title="Cancel">
+                                                            <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="cancelButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="JrD-Tn-miR"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
+                                                        <rect key="frame" x="89" y="0.0" width="79" height="50"/>
+                                                        <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
+                                                            <constraint firstAttribute="height" constant="50" id="99n-qk-tcW"/>
                                                         </constraints>
-                                                        <nil key="textColor"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
+                                                        <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
+                                                        <state key="normal" title="Save">
+                                                            <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </state>
+                                                        <connections>
+                                                            <action selector="saveButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="nrL-HT-cR4"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
-                                                <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                                <rect key="frame" x="0.0" y="152" width="325" height="61"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
-                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
-                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
-                                                        </constraints>
-                                                        <nil key="textColor"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
-                                                </subviews>
-                                                <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                                <rect key="frame" x="0.0" y="228" width="325" height="61"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
-                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
-                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
-                                                        </constraints>
-                                                        <nil key="textColor"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
-                                                </subviews>
-                                                <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
-                                                <rect key="frame" x="0.0" y="304" width="325" height="61"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
-                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
-                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
-                                                        </constraints>
-                                                        <nil key="textColor"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
-                                                    </textField>
-                                                </subviews>
-                                                <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>
-                                            </stackView>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="41W-1g-jcJ">
-                                        <rect key="frame" x="0.0" y="375" width="325" height="50"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aR0-VD-u1Y">
-                                                <rect key="frame" x="0.0" y="0.0" width="157.5" height="50"/>
-                                                <color key="backgroundColor" red="1" green="0.0" blue="0.058155415100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="50" id="V6M-5Y-lHq"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
-                                                <state key="normal" title="Cancel">
-                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </state>
-                                                <connections>
-                                                    <action selector="cancelButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="JrD-Tn-miR"/>
-                                                </connections>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
-                                                <rect key="frame" x="167.5" y="0.0" width="157.5" height="50"/>
-                                                <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="50" id="99n-qk-tcW"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
-                                                <state key="normal" title="Save">
-                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                </state>
-                                                <connections>
-                                                    <action selector="saveButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="nrL-HT-cR4"/>
-                                                </connections>
-                                            </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="41W-1g-jcJ" secondAttribute="bottom" id="csv-EG-Sht"/>
-                                    <constraint firstAttribute="trailing" secondItem="41W-1g-jcJ" secondAttribute="trailing" id="csy-2e-ANM"/>
-                                    <constraint firstItem="41W-1g-jcJ" firstAttribute="leading" secondItem="9k6-gS-BUM" secondAttribute="leading" id="mBO-VY-KYN"/>
+                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="mWU-tC-fcY" secondAttribute="top" constant="50" id="BJg-ml-Kz4"/>
+                                    <constraint firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" id="HfI-tG-bMo"/>
+                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="mWU-tC-fcY" secondAttribute="leading" constant="50" id="u3u-LS-DOP"/>
+                                    <constraint firstAttribute="bottom" secondItem="9k6-gS-BUM" secondAttribute="bottom" id="zmi-Gf-qGC"/>
                                 </constraints>
-                            </stackView>
+                            </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="50" id="CVc-1Y-ESd"/>
-                            <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" constant="25" id="K8d-EC-7I0"/>
-                            <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" constant="25" id="dLd-wE-fgJ"/>
-                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="9k6-gS-BUM" secondAttribute="bottom" constant="10" id="omG-yb-1ww"/>
+                            <constraint firstItem="mWU-tC-fcY" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" id="DJv-CQ-fLE"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="mWU-tC-fcY" secondAttribute="bottom" id="JUB-Mz-4XD"/>
+                            <constraint firstItem="mWU-tC-fcY" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" id="MGj-7q-bkn"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="mWU-tC-fcY" secondAttribute="trailing" id="c2S-rU-u7y"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>
@@ -282,6 +288,7 @@
                         <outlet property="foodTextField" destination="M1y-0Q-NCC" id="9Rc-0T-QIu"/>
                         <outlet property="proteinLabel" destination="wMr-lm-Wwn" id="0VV-Ew-SWe"/>
                         <outlet property="proteinTextField" destination="MWS-Hp-BmK" id="ghV-Qm-pb1"/>
+                        <outlet property="scrollView" destination="mWU-tC-fcY" id="M3G-uM-Uh6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jfY-pd-ivc" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -326,41 +333,41 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodNameLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jXi-uR-aoY">
-                                        <rect key="frame" x="76" y="0.0" width="223.5" height="57"/>
+                                        <rect key="frame" x="76" y="0.0" width="223.5" height="95.5"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="28"/>
                                         <color key="textColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-qa-hZr">
-                                        <rect key="frame" x="122" y="57" width="131.5" height="40.5"/>
+                                        <rect key="frame" x="122" y="95.5" width="131.5" height="68.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <color key="textColor" red="0.43968416960000001" green="0.44130747129999998" blue="0.41126847030000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="97.5" width="315" height="0.0"/>
+                                        <rect key="frame" x="30" y="164" width="315" height="171"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="50" y="97.5" width="275" height="116.5"/>
+                                        <rect key="frame" x="50" y="335" width="275" height="196.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="29.5" width="265" height="57.5"/>
+                                                <rect key="frame" x="0.0" y="69.5" width="265" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="270" y="29.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="270" y="69.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="275" y="29.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="275" y="69.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
@@ -368,7 +375,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="214" width="142" height="389"/>
+                                        <rect key="frame" x="116.5" y="531.5" width="142" height="71.5"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -98,16 +98,16 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
-                                        <rect key="frame" x="25" y="50" width="325" height="425"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="425"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="365"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="365"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
                                                                 </constraints>
@@ -116,7 +116,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
                                                                 </constraints>
@@ -127,10 +127,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                                        <rect key="frame" x="0.0" y="76" width="325" height="61"/>
+                                                        <rect key="frame" x="0.0" y="76" width="375" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
-                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
                                                                 </constraints>
@@ -139,7 +139,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
-                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
                                                                 </constraints>
@@ -151,10 +151,10 @@
                                                         <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                                        <rect key="frame" x="0.0" y="152" width="325" height="61"/>
+                                                        <rect key="frame" x="0.0" y="152" width="375" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
-                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
                                                                 </constraints>
@@ -163,7 +163,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
-                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
                                                                 </constraints>
@@ -175,10 +175,10 @@
                                                         <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                                        <rect key="frame" x="0.0" y="228" width="325" height="61"/>
+                                                        <rect key="frame" x="0.0" y="228" width="375" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
-                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
                                                                 </constraints>
@@ -187,7 +187,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
-                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
                                                                 </constraints>
@@ -199,10 +199,10 @@
                                                         <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
-                                                        <rect key="frame" x="0.0" y="304" width="325" height="61"/>
+                                                        <rect key="frame" x="0.0" y="304" width="375" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
-                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
                                                                 </constraints>
@@ -211,7 +211,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
-                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
                                                                 </constraints>
@@ -225,10 +225,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="41W-1g-jcJ">
-                                                <rect key="frame" x="0.0" y="375" width="325" height="50"/>
+                                                <rect key="frame" x="0.0" y="375" width="375" height="50"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aR0-VD-u1Y">
-                                                        <rect key="frame" x="0.0" y="0.0" width="157.5" height="50"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="182.5" height="50"/>
                                                         <color key="backgroundColor" red="1" green="0.0" blue="0.058155415100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="V6M-5Y-lHq"/>
@@ -242,7 +242,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
-                                                        <rect key="frame" x="167.5" y="0.0" width="157.5" height="50"/>
+                                                        <rect key="frame" x="192.5" y="0.0" width="182.5" height="50"/>
                                                         <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="99n-qk-tcW"/>
@@ -261,10 +261,10 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="mWU-tC-fcY" secondAttribute="top" constant="50" id="BJg-ml-Kz4"/>
-                                    <constraint firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" constant="25" id="HfI-tG-bMo"/>
-                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="mWU-tC-fcY" secondAttribute="leading" constant="25" id="u3u-LS-DOP"/>
-                                    <constraint firstAttribute="bottom" secondItem="9k6-gS-BUM" secondAttribute="bottom" id="zmi-Gf-qGC"/>
+                                    <constraint firstAttribute="bottom" secondItem="9k6-gS-BUM" secondAttribute="bottom" id="Foa-kJ-ZMC"/>
+                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="mWU-tC-fcY" secondAttribute="top" id="Ili-1C-fIm"/>
+                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="mWU-tC-fcY" secondAttribute="leading" id="OgK-Ht-eTC"/>
+                                    <constraint firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" id="y5H-ug-C0v"/>
                                 </constraints>
                             </scrollView>
                         </subviews>
@@ -274,7 +274,7 @@
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="mWU-tC-fcY" secondAttribute="bottom" id="JUB-Mz-4XD"/>
                             <constraint firstItem="mWU-tC-fcY" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" id="MGj-7q-bkn"/>
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="mWU-tC-fcY" secondAttribute="trailing" id="c2S-rU-u7y"/>
-                            <constraint firstItem="9k6-gS-BUM" firstAttribute="centerX" secondItem="ryl-eW-WfL" secondAttribute="centerX" id="j5z-DI-voe"/>
+                            <constraint firstItem="9k6-gS-BUM" firstAttribute="width" secondItem="sMa-4f-rWs" secondAttribute="width" id="iou-5H-lGJ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>
@@ -334,41 +334,41 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodNameLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jXi-uR-aoY">
-                                        <rect key="frame" x="76" y="0.0" width="223.5" height="95.5"/>
+                                        <rect key="frame" x="76" y="0.0" width="223.5" height="57"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="28"/>
                                         <color key="textColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-qa-hZr">
-                                        <rect key="frame" x="122" y="95.5" width="131.5" height="68.5"/>
+                                        <rect key="frame" x="122" y="57" width="131.5" height="40.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <color key="textColor" red="0.43968416960000001" green="0.44130747129999998" blue="0.41126847030000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="164" width="315" height="171"/>
+                                        <rect key="frame" x="30" y="97.5" width="315" height="0.0"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="50" y="335" width="275" height="196.5"/>
+                                        <rect key="frame" x="50" y="97.5" width="275" height="116.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="69.5" width="265" height="57.5"/>
+                                                <rect key="frame" x="0.0" y="29.5" width="265" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="270" y="69.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="270" y="29.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="275" y="69.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="275" y="29.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
@@ -376,7 +376,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="531.5" width="142" height="71.5"/>
+                                        <rect key="frame" x="116.5" y="214" width="142" height="389"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -98,7 +98,7 @@
                                 <rect key="frame" x="25" y="89" width="325" height="553"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="492.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="432"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -107,7 +107,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="472"/>
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="411.5"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -115,7 +115,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                        <rect key="frame" x="0.0" y="442" width="325" height="50.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -131,6 +131,24 @@
                                             </textField>
                                         </subviews>
                                         <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
+                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="proteinTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
                                     </stackView>
                                 </subviews>
                             </stackView>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -241,7 +241,7 @@
                                                                     <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 </state>
                                                                 <connections>
-                                                                    <action selector="cancelButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="JrD-Tn-miR"/>
+                                                                    <action selector="cancel:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="JrD-Tn-miR"/>
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
@@ -255,7 +255,7 @@
                                                                     <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 </state>
                                                                 <connections>
-                                                                    <action selector="saveButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="nrL-HT-cR4"/>
+                                                                    <action selector="save:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="nrL-HT-cR4"/>
                                                                 </connections>
                                                             </button>
                                                         </subviews>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -45,6 +45,8 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="3Av-dc-ZJx" firstAttribute="leading" secondItem="2et-to-Yfo" secondAttribute="leading" constant="95" id="VCz-FM-vyi"/>
+                                    <constraint firstAttribute="trailing" secondItem="3Av-dc-ZJx" secondAttribute="trailing" constant="95" id="gg8-Pt-KhQ"/>
+                                    <constraint firstAttribute="trailing" secondItem="TbK-UU-xng" secondAttribute="trailing" constant="88" id="miB-fO-3wr"/>
                                     <constraint firstItem="TbK-UU-xng" firstAttribute="leading" secondItem="2et-to-Yfo" secondAttribute="leading" constant="88" id="x3S-Nx-cWF"/>
                                 </constraints>
                             </stackView>
@@ -114,29 +116,29 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="48" width="315" height="476.5"/>
+                                        <rect key="frame" x="30" y="48" width="315" height="0.0"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="50" y="524.5" width="275" height="57.5"/>
+                                        <rect key="frame" x="50" y="48" width="275" height="57.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="265" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="5" y="0.0" width="79" height="57.5"/>
+                                                <rect key="frame" x="270" y="0.0" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="89" y="0.0" width="186" height="57.5"/>
+                                                <rect key="frame" x="275" y="0.0" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
@@ -144,7 +146,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="582" width="142" height="21"/>
+                                        <rect key="frame" x="116.5" y="105.5" width="142" height="497.5"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -83,6 +83,21 @@
             </objects>
             <point key="canvasLocation" x="892" y="59.820089955022496"/>
         </scene>
+        <!--Food Entry View Controller-->
+        <scene sceneID="YDY-92-eQv">
+            <objects>
+                <viewController id="GUX-mL-Ygv" customClass="FoodEntryViewController" customModule="GetFed" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="sMa-4f-rWs">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jfY-pd-ivc" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1977" y="-90"/>
+        </scene>
         <!--Food Search View Controller-->
         <scene sceneID="K15-kv-ocW">
             <objects>
@@ -107,7 +122,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nts-7g-0EP" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2162" y="75"/>
+            <point key="canvasLocation" x="1977" y="654"/>
         </scene>
         <!--Food Detail View Controller-->
         <scene sceneID="XbU-TW-66P">
@@ -200,7 +215,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="t5Z-hq-KYj" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3131" y="78"/>
+            <point key="canvasLocation" x="3095" y="654"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="IpI-tR-bRq">

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -94,11 +94,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
                                 <rect key="frame" x="25" y="89" width="325" height="553"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="311"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="102.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -106,16 +106,16 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="290.5"/>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="82"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                        <rect key="frame" x="0.0" y="321" width="325" height="50.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
+                                        <rect key="frame" x="0.0" y="112.5" width="325" height="102.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -123,7 +123,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="brandTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="brandTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
                                                 <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -132,8 +132,8 @@
                                         </subviews>
                                         <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                        <rect key="frame" x="0.0" y="381.5" width="325" height="50.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
+                                        <rect key="frame" x="0.0" y="225" width="325" height="103"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -141,7 +141,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="proteinTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="proteinTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
                                                 <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -150,8 +150,8 @@
                                         </subviews>
                                         <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                        <rect key="frame" x="0.0" y="442" width="325" height="50.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
+                                        <rect key="frame" x="0.0" y="338" width="325" height="102.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -159,7 +159,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="carbsTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="carbsTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
                                                 <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -168,8 +168,8 @@
                                         </subviews>
                                         <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
-                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
+                                        <rect key="frame" x="0.0" y="450.5" width="325" height="102.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -177,7 +177,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="fatTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="fatTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
                                                 <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -241,41 +241,41 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodNameLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jXi-uR-aoY">
-                                        <rect key="frame" x="76" y="0.0" width="223.5" height="28"/>
+                                        <rect key="frame" x="76" y="0.0" width="223.5" height="95.5"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="28"/>
                                         <color key="textColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-qa-hZr">
-                                        <rect key="frame" x="122" y="28" width="131.5" height="20"/>
+                                        <rect key="frame" x="122" y="95.5" width="131.5" height="68.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <color key="textColor" red="0.43968416960000001" green="0.44130747129999998" blue="0.41126847030000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="48" width="315" height="0.0"/>
+                                        <rect key="frame" x="30" y="164" width="315" height="171"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="50" y="48" width="275" height="57.5"/>
+                                        <rect key="frame" x="50" y="335" width="275" height="196.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="0.0" width="265" height="57.5"/>
+                                                <rect key="frame" x="0.0" y="98" width="265" height="0.0"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="270" y="0.0" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="270" y="69.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="275" y="0.0" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="275" y="69.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
@@ -283,7 +283,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="105.5" width="142" height="497.5"/>
+                                        <rect key="frame" x="116.5" y="531.5" width="142" height="71.5"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -94,137 +94,169 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
-                                <rect key="frame" x="25" y="264" width="325" height="365"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
+                                <rect key="frame" x="25" y="239" width="325" height="425"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="365"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
+                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
+                                                        </constraints>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
+                                                <rect key="frame" x="0.0" y="76" width="325" height="61"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
+                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="brandTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
+                                                        </constraints>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
+                                                <rect key="frame" x="0.0" y="152" width="325" height="61"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
+                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="proteinTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
+                                                        </constraints>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
+                                                <rect key="frame" x="0.0" y="228" width="325" height="61"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
+                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="carbsTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
+                                                        </constraints>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
+                                                <rect key="frame" x="0.0" y="304" width="325" height="61"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
+                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="fatTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
+                                                        </constraints>
+                                                        <nil key="textColor"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                </subviews>
+                                                <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                        <rect key="frame" x="0.0" y="76" width="325" height="61"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="41W-1g-jcJ">
+                                        <rect key="frame" x="0.0" y="375" width="325" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aR0-VD-u1Y">
+                                                <rect key="frame" x="0.0" y="0.0" width="157.5" height="50"/>
+                                                <color key="backgroundColor" red="1" green="0.0" blue="0.058155415100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
+                                                    <constraint firstAttribute="height" constant="50" id="V6M-5Y-lHq"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="brandTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
-                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
+                                                <state key="normal" title="Cancel">
+                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
+                                                <rect key="frame" x="167.5" y="0.0" width="157.5" height="50"/>
+                                                <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
+                                                    <constraint firstAttribute="height" constant="50" id="99n-qk-tcW"/>
                                                 </constraints>
-                                                <nil key="textColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
+                                                <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
+                                                <state key="normal" title="Save">
+                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                            </button>
                                         </subviews>
-                                        <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                        <rect key="frame" x="0.0" y="152" width="325" height="61"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="proteinTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
-                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                        </subviews>
-                                        <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                        <rect key="frame" x="0.0" y="228" width="325" height="61"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="carbsTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
-                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                        </subviews>
-                                        <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
-                                        <rect key="frame" x="0.0" y="304" width="325" height="61"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="fatTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
-                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
-                                                </constraints>
-                                                <nil key="textColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                        </subviews>
-                                        <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>
                                     </stackView>
                                 </subviews>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="S9c-if-MJV" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" constant="25" id="RXz-WF-85p"/>
-                            <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="S9c-if-MJV" secondAttribute="trailing" constant="25" id="Vjt-rw-CVg"/>
-                            <constraint firstItem="S9c-if-MJV" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="200" id="Yp7-Pa-fGN"/>
-                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="S9c-if-MJV" secondAttribute="bottom" constant="200" id="dJG-YO-lJw"/>
+                            <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="175" id="CVc-1Y-ESd"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" constant="25" id="K8d-EC-7I0"/>
+                            <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" constant="25" id="dLd-wE-fgJ"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="9k6-gS-BUM" secondAttribute="bottom" constant="175" id="omG-yb-1ww"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -53,6 +53,7 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="rtn-VN-gk8" firstAttribute="trailing" secondItem="2et-to-Yfo" secondAttribute="trailing" constant="25" id="QIX-L9-r6A"/>
                             <constraint firstItem="rtn-VN-gk8" firstAttribute="bottom" secondItem="2et-to-Yfo" secondAttribute="bottom" constant="25" id="d5z-gL-AB0"/>
                             <constraint firstItem="2et-to-Yfo" firstAttribute="centerX" secondItem="X9B-AA-Vx6" secondAttribute="centerX" id="hH6-xg-eVx"/>
                             <constraint firstItem="2et-to-Yfo" firstAttribute="leading" secondItem="rtn-VN-gk8" secondAttribute="leading" constant="25" id="ibk-Y1-WmG"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -94,20 +94,26 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
-                                <rect key="frame" x="25" y="89" width="325" height="553"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
+                                <rect key="frame" x="25" y="264" width="325" height="365"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="102.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="82"/>
+                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
+                                                </constraints>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -115,16 +121,22 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                        <rect key="frame" x="0.0" y="112.5" width="325" height="102.5"/>
+                                        <rect key="frame" x="0.0" y="76" width="325" height="61"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="brandTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
+                                                </constraints>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -133,16 +145,22 @@
                                         <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                        <rect key="frame" x="0.0" y="225" width="325" height="103"/>
+                                        <rect key="frame" x="0.0" y="152" width="325" height="61"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="proteinTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
+                                                </constraints>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -151,16 +169,22 @@
                                         <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                        <rect key="frame" x="0.0" y="338" width="325" height="102.5"/>
+                                        <rect key="frame" x="0.0" y="228" width="325" height="61"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="carbsTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
+                                                </constraints>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -169,16 +193,22 @@
                                         <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
-                                        <rect key="frame" x="0.0" y="450.5" width="325" height="102.5"/>
+                                        <rect key="frame" x="0.0" y="304" width="325" height="61"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
-                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="fatTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
+                                                </constraints>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -193,8 +223,8 @@
                         <constraints>
                             <constraint firstItem="S9c-if-MJV" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" constant="25" id="RXz-WF-85p"/>
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="S9c-if-MJV" secondAttribute="trailing" constant="25" id="Vjt-rw-CVg"/>
-                            <constraint firstItem="S9c-if-MJV" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="25" id="Yp7-Pa-fGN"/>
-                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="S9c-if-MJV" secondAttribute="bottom" constant="25" id="dJG-YO-lJw"/>
+                            <constraint firstItem="S9c-if-MJV" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="200" id="Yp7-Pa-fGN"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="S9c-if-MJV" secondAttribute="bottom" constant="200" id="dJG-YO-lJw"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>
@@ -227,7 +257,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="nts-7g-0EP" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1977" y="654"/>
+            <point key="canvasLocation" x="1977" y="1127"/>
         </scene>
         <!--Food Detail View Controller-->
         <scene sceneID="XbU-TW-66P">
@@ -241,41 +271,41 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodNameLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jXi-uR-aoY">
-                                        <rect key="frame" x="76" y="0.0" width="223.5" height="95.5"/>
+                                        <rect key="frame" x="76" y="0.0" width="223.5" height="57"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="28"/>
                                         <color key="textColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-qa-hZr">
-                                        <rect key="frame" x="122" y="95.5" width="131.5" height="68.5"/>
+                                        <rect key="frame" x="122" y="57" width="131.5" height="40.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <color key="textColor" red="0.43968416960000001" green="0.44130747129999998" blue="0.41126847030000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="164" width="315" height="171"/>
+                                        <rect key="frame" x="30" y="97.5" width="315" height="0.0"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="50" y="335" width="275" height="196.5"/>
+                                        <rect key="frame" x="50" y="97.5" width="275" height="116.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="98" width="265" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="29.5" width="265" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="270" y="69.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="270" y="29.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="275" y="69.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="275" y="29.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
@@ -283,7 +313,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="531.5" width="142" height="71.5"/>
+                                        <rect key="frame" x="116.5" y="214" width="142" height="389"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -302,7 +302,6 @@
                         <outlet property="foodTextField" destination="M1y-0Q-NCC" id="9Rc-0T-QIu"/>
                         <outlet property="proteinLabel" destination="wMr-lm-Wwn" id="0VV-Ew-SWe"/>
                         <outlet property="proteinTextField" destination="MWS-Hp-BmK" id="ghV-Qm-pb1"/>
-                        <outlet property="scrollView" destination="mWU-tC-fcY" id="M3G-uM-Uh6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jfY-pd-ivc" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -28,26 +28,30 @@
                                         <color key="textColor" red="0.0062921650152418648" green="0.37506285919540228" blue="0.028588568390094854" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TbK-UU-xng">
-                                        <rect key="frame" x="88" y="478" width="149" height="75"/>
-                                        <color key="backgroundColor" red="0.37506285919540228" green="0.066743286643183783" blue="0.32412731209726553" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="75" id="i6K-Ai-znH"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
-                                        <state key="normal" title="Food Search">
-                                            <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <segue destination="eoP-H5-PUG" kind="show" identifier="homeToFoodSearch" id="Csl-jx-NKu"/>
-                                        </connections>
-                                    </button>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fQH-3o-N8x">
+                                        <rect key="frame" x="82.5" y="478" width="160" height="75"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TbK-UU-xng">
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="75"/>
+                                                <color key="backgroundColor" red="0.37506285919540228" green="0.066743286643183783" blue="0.32412731209726553" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="160" id="MvY-Yp-4em"/>
+                                                    <constraint firstAttribute="height" constant="75" id="i6K-Ai-znH"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
+                                                <state key="normal" title="Food Search">
+                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <segue destination="eoP-H5-PUG" kind="show" identifier="homeToFoodSearch" id="Csl-jx-NKu"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="3Av-dc-ZJx" firstAttribute="leading" secondItem="2et-to-Yfo" secondAttribute="leading" constant="95" id="VCz-FM-vyi"/>
                                     <constraint firstAttribute="trailing" secondItem="3Av-dc-ZJx" secondAttribute="trailing" constant="95" id="gg8-Pt-KhQ"/>
-                                    <constraint firstAttribute="trailing" secondItem="TbK-UU-xng" secondAttribute="trailing" constant="88" id="miB-fO-3wr"/>
-                                    <constraint firstItem="TbK-UU-xng" firstAttribute="leading" secondItem="2et-to-Yfo" secondAttribute="leading" constant="88" id="x3S-Nx-cWF"/>
                                 </constraints>
                             </stackView>
                         </subviews>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -98,7 +98,7 @@
                                 <rect key="frame" x="25" y="89" width="325" height="553"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="371.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="311"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -107,7 +107,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="351"/>
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="290.5"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -115,7 +115,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                        <rect key="frame" x="0.0" y="381.5" width="325" height="50.5"/>
+                                        <rect key="frame" x="0.0" y="321" width="325" height="50.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -133,7 +133,7 @@
                                         <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                        <rect key="frame" x="0.0" y="442" width="325" height="50.5"/>
+                                        <rect key="frame" x="0.0" y="381.5" width="325" height="50.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -151,7 +151,7 @@
                                         <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                        <rect key="frame" x="0.0" y="442" width="325" height="50.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -167,6 +167,24 @@
                                             </textField>
                                         </subviews>
                                         <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
+                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="fatTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>
                                     </stackView>
                                 </subviews>
                             </stackView>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -109,7 +109,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
                                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Food Name:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
@@ -132,7 +132,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
                                                                 <rect key="frame" x="0.0" y="76" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Brand Name:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
@@ -156,7 +156,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
                                                                 <rect key="frame" x="0.0" y="152" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Protein amount in grams (per 100 grams)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
@@ -180,7 +180,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
                                                                 <rect key="frame" x="0.0" y="228" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs amount in grams (per 100 grams)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
@@ -204,7 +204,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
                                                                 <rect key="frame" x="0.0" y="304" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fat amount in grams (per 100 grams)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -234,6 +234,9 @@
                                                 <state key="normal" title="Cancel">
                                                     <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="cancelButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="JrD-Tn-miR"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
                                                 <rect key="frame" x="167.5" y="0.0" width="157.5" height="50"/>
@@ -245,6 +248,9 @@
                                                 <state key="normal" title="Save">
                                                     <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
+                                                <connections>
+                                                    <action selector="saveButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="nrL-HT-cR4"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -94,11 +94,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
                                 <rect key="frame" x="25" y="89" width="325" height="553"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="553"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="492.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -106,13 +106,31 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="532.5"/>
+                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="472"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                         </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
+                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="brandTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                     </stackView>
                                 </subviews>
                             </stackView>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -228,6 +228,13 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>
+                    <connections>
+                        <outlet property="brandTextField" destination="jnd-X3-13o" id="gTK-NY-BGP"/>
+                        <outlet property="carbsTextField" destination="KtU-NS-OKS" id="4G9-Ee-JQb"/>
+                        <outlet property="fatTextField" destination="gvS-7T-Fnk" id="oYY-NM-Cdn"/>
+                        <outlet property="foodTextField" destination="M1y-0Q-NCC" id="9Rc-0T-QIu"/>
+                        <outlet property="proteinTextField" destination="MWS-Hp-BmK" id="ghV-Qm-pb1"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jfY-pd-ivc" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -95,7 +95,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
-                                <rect key="frame" x="25" y="239" width="325" height="425"/>
+                                <rect key="frame" x="25" y="114" width="325" height="425"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
                                         <rect key="frame" x="0.0" y="0.0" width="325" height="365"/>
@@ -255,14 +255,19 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="41W-1g-jcJ" secondAttribute="bottom" id="csv-EG-Sht"/>
+                                    <constraint firstAttribute="trailing" secondItem="41W-1g-jcJ" secondAttribute="trailing" id="csy-2e-ANM"/>
+                                    <constraint firstItem="41W-1g-jcJ" firstAttribute="leading" secondItem="9k6-gS-BUM" secondAttribute="leading" id="mBO-VY-KYN"/>
+                                </constraints>
                             </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="175" id="CVc-1Y-ESd"/>
+                            <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="50" id="CVc-1Y-ESd"/>
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" constant="25" id="K8d-EC-7I0"/>
                             <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" constant="25" id="dLd-wE-fgJ"/>
-                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="9k6-gS-BUM" secondAttribute="bottom" constant="175" id="omG-yb-1ww"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="9k6-gS-BUM" secondAttribute="bottom" constant="10" id="omG-yb-1ww"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -272,10 +272,15 @@
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>
                     <connections>
+                        <outlet property="brandLabel" destination="SIW-Kn-UL9" id="6Ba-gg-JcO"/>
                         <outlet property="brandTextField" destination="jnd-X3-13o" id="gTK-NY-BGP"/>
+                        <outlet property="carbsLabel" destination="wzu-iU-PFb" id="ZM1-Ns-j8f"/>
                         <outlet property="carbsTextField" destination="KtU-NS-OKS" id="4G9-Ee-JQb"/>
+                        <outlet property="fatLabel" destination="XA0-5V-DVR" id="8XT-EP-8vK"/>
                         <outlet property="fatTextField" destination="gvS-7T-Fnk" id="oYY-NM-Cdn"/>
+                        <outlet property="foodLabel" destination="vzV-UP-cyX" id="Lja-lu-YRp"/>
                         <outlet property="foodTextField" destination="M1y-0Q-NCC" id="9Rc-0T-QIu"/>
+                        <outlet property="proteinLabel" destination="wMr-lm-Wwn" id="0VV-Ew-SWe"/>
                         <outlet property="proteinTextField" destination="MWS-Hp-BmK" id="ghV-Qm-pb1"/>
                     </connections>
                 </viewController>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -172,7 +172,7 @@
                                                                         </constraints>
                                                                         <nil key="textColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                        <textInputTraits key="textInputTraits"/>
+                                                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                                     </textField>
                                                                 </subviews>
                                                                 <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
@@ -196,7 +196,7 @@
                                                                         </constraints>
                                                                         <nil key="textColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                        <textInputTraits key="textInputTraits"/>
+                                                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                                     </textField>
                                                                 </subviews>
                                                                 <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
@@ -220,7 +220,7 @@
                                                                         </constraints>
                                                                         <nil key="textColor"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                        <textInputTraits key="textInputTraits"/>
+                                                                        <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                                     </textField>
                                                                 </subviews>
                                                                 <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -42,6 +42,9 @@
                                                 <state key="normal" title="Food Entry">
                                                     <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
+                                                <connections>
+                                                    <segue destination="GUX-mL-Ygv" kind="show" id="gbs-Rz-zsT"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TbK-UU-xng">
                                                 <rect key="frame" x="0.0" y="95" width="160" height="75"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -98,16 +98,16 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
-                                        <rect key="frame" x="50" y="50" width="168" height="425"/>
+                                        <rect key="frame" x="25" y="50" width="325" height="425"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
-                                                <rect key="frame" x="0.0" y="0.0" width="168" height="365"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="365"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                                        <rect key="frame" x="0.0" y="0.0" width="168" height="61"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
                                                                 </constraints>
@@ -116,7 +116,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
                                                                 </constraints>
@@ -127,10 +127,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                                        <rect key="frame" x="0.0" y="76" width="168" height="61"/>
+                                                        <rect key="frame" x="0.0" y="76" width="325" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
-                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
                                                                 </constraints>
@@ -139,7 +139,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
-                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
                                                                 </constraints>
@@ -151,10 +151,10 @@
                                                         <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                                        <rect key="frame" x="0.0" y="152" width="168" height="61"/>
+                                                        <rect key="frame" x="0.0" y="152" width="325" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
-                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
                                                                 </constraints>
@@ -163,7 +163,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
-                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
                                                                 </constraints>
@@ -175,10 +175,10 @@
                                                         <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                                        <rect key="frame" x="0.0" y="228" width="168" height="61"/>
+                                                        <rect key="frame" x="0.0" y="228" width="325" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
-                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
                                                                 </constraints>
@@ -187,7 +187,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
-                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
                                                                 </constraints>
@@ -199,10 +199,10 @@
                                                         <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
-                                                        <rect key="frame" x="0.0" y="304" width="168" height="61"/>
+                                                        <rect key="frame" x="0.0" y="304" width="325" height="61"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
-                                                                <rect key="frame" x="0.0" y="0.0" width="168" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
                                                                 </constraints>
@@ -211,7 +211,7 @@
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
-                                                                <rect key="frame" x="0.0" y="25" width="168" height="36"/>
+                                                                <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
                                                                 </constraints>
@@ -225,10 +225,10 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="41W-1g-jcJ">
-                                                <rect key="frame" x="0.0" y="375" width="168" height="50"/>
+                                                <rect key="frame" x="0.0" y="375" width="325" height="50"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aR0-VD-u1Y">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="50"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="157.5" height="50"/>
                                                         <color key="backgroundColor" red="1" green="0.0" blue="0.058155415100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="V6M-5Y-lHq"/>
@@ -242,7 +242,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
-                                                        <rect key="frame" x="89" y="0.0" width="79" height="50"/>
+                                                        <rect key="frame" x="167.5" y="0.0" width="157.5" height="50"/>
                                                         <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="50" id="99n-qk-tcW"/>
@@ -262,8 +262,8 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="mWU-tC-fcY" secondAttribute="top" constant="50" id="BJg-ml-Kz4"/>
-                                    <constraint firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" id="HfI-tG-bMo"/>
-                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="mWU-tC-fcY" secondAttribute="leading" constant="50" id="u3u-LS-DOP"/>
+                                    <constraint firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" constant="25" id="HfI-tG-bMo"/>
+                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="mWU-tC-fcY" secondAttribute="leading" constant="25" id="u3u-LS-DOP"/>
                                     <constraint firstAttribute="bottom" secondItem="9k6-gS-BUM" secondAttribute="bottom" id="zmi-Gf-qGC"/>
                                 </constraints>
                             </scrollView>
@@ -274,6 +274,7 @@
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="mWU-tC-fcY" secondAttribute="bottom" id="JUB-Mz-4XD"/>
                             <constraint firstItem="mWU-tC-fcY" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" id="MGj-7q-bkn"/>
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="mWU-tC-fcY" secondAttribute="trailing" id="c2S-rU-u7y"/>
+                            <constraint firstItem="9k6-gS-BUM" firstAttribute="centerX" secondItem="ryl-eW-WfL" secondAttribute="centerX" id="j5z-DI-voe"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -23,16 +23,28 @@
                                 <rect key="frame" x="25" y="89" width="325" height="553"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GetFed" textAlignment="natural" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Av-dc-ZJx">
-                                        <rect key="frame" x="95" y="0.0" width="135" height="189"/>
+                                        <rect key="frame" x="95" y="0.0" width="135" height="94"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="48"/>
                                         <color key="textColor" red="0.0062921650152418648" green="0.37506285919540228" blue="0.028588568390094854" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fQH-3o-N8x">
-                                        <rect key="frame" x="82.5" y="478" width="160" height="75"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="fQH-3o-N8x">
+                                        <rect key="frame" x="82.5" y="383" width="160" height="170"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TbK-UU-xng">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vSD-hB-mW9">
                                                 <rect key="frame" x="0.0" y="0.0" width="160" height="75"/>
+                                                <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="75" id="STk-I9-2FK"/>
+                                                    <constraint firstAttribute="width" constant="160" id="mTE-ib-kMA"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
+                                                <state key="normal" title="Food Entry">
+                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TbK-UU-xng">
+                                                <rect key="frame" x="0.0" y="95" width="160" height="75"/>
                                                 <color key="backgroundColor" red="0.37506285919540228" green="0.066743286643183783" blue="0.32412731209726553" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="160" id="MvY-Yp-4em"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -98,7 +98,7 @@
                                 <rect key="frame" x="25" y="89" width="325" height="553"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                        <rect key="frame" x="0.0" y="0.0" width="325" height="432"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="371.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -107,7 +107,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                <rect key="frame" x="0.0" y="20.5" width="325" height="411.5"/>
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="351"/>
                                                 <nil key="textColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -115,7 +115,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                        <rect key="frame" x="0.0" y="442" width="325" height="50.5"/>
+                                        <rect key="frame" x="0.0" y="381.5" width="325" height="50.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -133,7 +133,7 @@
                                         <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                        <rect key="frame" x="0.0" y="442" width="325" height="50.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
@@ -149,6 +149,24 @@
                                             </textField>
                                         </subviews>
                                         <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
+                                        <rect key="frame" x="0.0" y="502.5" width="325" height="50.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="carbsTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="30"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
                                     </stackView>
                                 </subviews>
                             </stackView>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -97,184 +97,197 @@
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mWU-tC-fcY">
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="425"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rIh-VP-Ggv">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="365"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9k6-gS-BUM">
+                                                <rect key="frame" x="25" y="50" width="325" height="425"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
-                                                        <rect key="frame" x="0.0" y="0.0" width="375" height="61"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
+                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="365"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
-                                                                </constraints>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
-                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
-                                                                </constraints>
-                                                                <nil key="textColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits"/>
-                                                            </textField>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
+                                                                <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
+                                                                        </constraints>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
+                                                                        </constraints>
+                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
+                                                                <rect key="frame" x="0.0" y="76" width="325" height="61"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
+                                                                        </constraints>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
+                                                                        </constraints>
+                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
+                                                                <rect key="frame" x="0.0" y="152" width="325" height="61"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
+                                                                        </constraints>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
+                                                                        </constraints>
+                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
+                                                                <rect key="frame" x="0.0" y="228" width="325" height="61"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
+                                                                        </constraints>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
+                                                                        </constraints>
+                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
+                                                                <rect key="frame" x="0.0" y="304" width="325" height="61"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
+                                                                        </constraints>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                                        <rect key="frame" x="0.0" y="25" width="325" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
+                                                                        </constraints>
+                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                        <textInputTraits key="textInputTraits"/>
+                                                                    </textField>
+                                                                </subviews>
+                                                                <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>
+                                                            </stackView>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
-                                                        <rect key="frame" x="0.0" y="76" width="375" height="61"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="41W-1g-jcJ">
+                                                        <rect key="frame" x="0.0" y="375" width="325" height="50"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aR0-VD-u1Y">
+                                                                <rect key="frame" x="0.0" y="0.0" width="157.5" height="50"/>
+                                                                <color key="backgroundColor" red="1" green="0.0" blue="0.058155415100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
+                                                                    <constraint firstAttribute="height" constant="50" id="V6M-5Y-lHq"/>
                                                                 </constraints>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
-                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
+                                                                <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
+                                                                <state key="normal" title="Cancel">
+                                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                </state>
+                                                                <connections>
+                                                                    <action selector="cancelButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="JrD-Tn-miR"/>
+                                                                </connections>
+                                                            </button>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
+                                                                <rect key="frame" x="167.5" y="0.0" width="157.5" height="50"/>
+                                                                <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
+                                                                    <constraint firstAttribute="height" constant="50" id="99n-qk-tcW"/>
                                                                 </constraints>
-                                                                <nil key="textColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits"/>
-                                                            </textField>
+                                                                <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
+                                                                <state key="normal" title="Save">
+                                                                    <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                </state>
+                                                                <connections>
+                                                                    <action selector="saveButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="nrL-HT-cR4"/>
+                                                                </connections>
+                                                            </button>
                                                         </subviews>
-                                                        <viewLayoutGuide key="safeArea" id="sOc-q6-lbm"/>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
-                                                        <rect key="frame" x="0.0" y="152" width="375" height="61"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
-                                                                </constraints>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
-                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
-                                                                </constraints>
-                                                                <nil key="textColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits"/>
-                                                            </textField>
-                                                        </subviews>
-                                                        <viewLayoutGuide key="safeArea" id="XFm-Bk-d5Y"/>
-                                                    </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
-                                                        <rect key="frame" x="0.0" y="228" width="375" height="61"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
-                                                                </constraints>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
-                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
-                                                                </constraints>
-                                                                <nil key="textColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits"/>
-                                                            </textField>
-                                                        </subviews>
-                                                        <viewLayoutGuide key="safeArea" id="HgD-de-duo"/>
-                                                    </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
-                                                        <rect key="frame" x="0.0" y="304" width="375" height="61"/>
-                                                        <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="25"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
-                                                                </constraints>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                <nil key="textColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
-                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
-                                                                <rect key="frame" x="0.0" y="25" width="375" height="36"/>
-                                                                <constraints>
-                                                                    <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
-                                                                </constraints>
-                                                                <nil key="textColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits"/>
-                                                            </textField>
-                                                        </subviews>
-                                                        <viewLayoutGuide key="safeArea" id="cKp-4c-LCY"/>
-                                                    </stackView>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="41W-1g-jcJ">
-                                                <rect key="frame" x="0.0" y="375" width="375" height="50"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aR0-VD-u1Y">
-                                                        <rect key="frame" x="0.0" y="0.0" width="182.5" height="50"/>
-                                                        <color key="backgroundColor" red="1" green="0.0" blue="0.058155415100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="V6M-5Y-lHq"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
-                                                        <state key="normal" title="Cancel">
-                                                            <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="cancelButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="JrD-Tn-miR"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WnV-Pb-qpV">
-                                                        <rect key="frame" x="192.5" y="0.0" width="182.5" height="50"/>
-                                                        <color key="backgroundColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="50" id="99n-qk-tcW"/>
-                                                        </constraints>
-                                                        <fontDescription key="fontDescription" name="Rockwell-Bold" family="Rockwell" pointSize="21"/>
-                                                        <state key="normal" title="Save">
-                                                            <color key="titleColor" red="0.99774772690000002" green="1" blue="0.97488382910000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </state>
-                                                        <connections>
-                                                            <action selector="saveButtonTapped:" destination="GUX-mL-Ygv" eventType="touchUpInside" id="nrL-HT-cR4"/>
-                                                        </connections>
-                                                    </button>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                    </stackView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="9k6-gS-BUM" secondAttribute="bottom" constant="10" id="415-CI-2i8"/>
+                                            <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="rIh-VP-Ggv" secondAttribute="leading" constant="25" id="cOp-dt-TcV"/>
+                                            <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="rIh-VP-Ggv" secondAttribute="top" constant="50" id="o3z-BV-VJk"/>
+                                            <constraint firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" constant="25" id="xvV-Xr-Zy3"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="9k6-gS-BUM" secondAttribute="bottom" id="Foa-kJ-ZMC"/>
-                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="top" secondItem="mWU-tC-fcY" secondAttribute="top" id="Ili-1C-fIm"/>
-                                    <constraint firstItem="9k6-gS-BUM" firstAttribute="leading" secondItem="mWU-tC-fcY" secondAttribute="leading" id="OgK-Ht-eTC"/>
-                                    <constraint firstAttribute="trailing" secondItem="9k6-gS-BUM" secondAttribute="trailing" id="y5H-ug-C0v"/>
+                                    <constraint firstItem="rIh-VP-Ggv" firstAttribute="top" secondItem="mWU-tC-fcY" secondAttribute="top" id="5MF-Js-9r2"/>
+                                    <constraint firstAttribute="bottom" secondItem="rIh-VP-Ggv" secondAttribute="bottom" id="GXF-Si-5e8"/>
+                                    <constraint firstItem="rIh-VP-Ggv" firstAttribute="leading" secondItem="mWU-tC-fcY" secondAttribute="leading" id="a3z-EG-lgJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="rIh-VP-Ggv" secondAttribute="trailing" id="yvg-ho-kyT"/>
                                 </constraints>
                             </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="rIh-VP-Ggv" firstAttribute="height" secondItem="sMa-4f-rWs" secondAttribute="height" id="BNO-Se-ol5"/>
                             <constraint firstItem="mWU-tC-fcY" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" id="DJv-CQ-fLE"/>
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="mWU-tC-fcY" secondAttribute="bottom" id="JUB-Mz-4XD"/>
                             <constraint firstItem="mWU-tC-fcY" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" id="MGj-7q-bkn"/>
+                            <constraint firstItem="rIh-VP-Ggv" firstAttribute="width" secondItem="sMa-4f-rWs" secondAttribute="width" id="WOi-FD-V9j"/>
                             <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="mWU-tC-fcY" secondAttribute="trailing" id="c2S-rU-u7y"/>
-                            <constraint firstItem="9k6-gS-BUM" firstAttribute="width" secondItem="sMa-4f-rWs" secondAttribute="width" id="iou-5H-lGJ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>
@@ -334,41 +347,41 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodNameLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jXi-uR-aoY">
-                                        <rect key="frame" x="76" y="0.0" width="223.5" height="57"/>
+                                        <rect key="frame" x="76" y="0.0" width="223.5" height="95.5"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="28"/>
                                         <color key="textColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-qa-hZr">
-                                        <rect key="frame" x="122" y="57" width="131.5" height="40.5"/>
+                                        <rect key="frame" x="122" y="95.5" width="131.5" height="68.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <color key="textColor" red="0.43968416960000001" green="0.44130747129999998" blue="0.41126847030000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="97.5" width="315" height="0.0"/>
+                                        <rect key="frame" x="30" y="164" width="315" height="171"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="50" y="97.5" width="275" height="116.5"/>
+                                        <rect key="frame" x="50" y="335" width="275" height="196.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="29.5" width="265" height="57.5"/>
+                                                <rect key="frame" x="0.0" y="69.5" width="265" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="270" y="29.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="270" y="69.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="275" y="29.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="275" y="69.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
@@ -376,7 +389,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="214" width="142" height="389"/>
+                                        <rect key="frame" x="116.5" y="531.5" width="142" height="71.5"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -93,7 +93,37 @@
                     <view key="view" contentMode="scaleToFill" id="sMa-4f-rWs">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="S9c-if-MJV">
+                                <rect key="frame" x="25" y="89" width="325" height="553"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" restorationIdentifier="Food" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
+                                        <rect key="frame" x="0.0" y="0.0" width="325" height="553"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
+                                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="foodTextField" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                <rect key="frame" x="0.0" y="20.5" width="325" height="532.5"/>
+                                                <nil key="textColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="S9c-if-MJV" firstAttribute="leading" secondItem="ryl-eW-WfL" secondAttribute="leading" constant="25" id="RXz-WF-85p"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="trailing" secondItem="S9c-if-MJV" secondAttribute="trailing" constant="25" id="Vjt-rw-CVg"/>
+                            <constraint firstItem="S9c-if-MJV" firstAttribute="top" secondItem="ryl-eW-WfL" secondAttribute="top" constant="25" id="Yp7-Pa-fGN"/>
+                            <constraint firstItem="ryl-eW-WfL" firstAttribute="bottom" secondItem="S9c-if-MJV" secondAttribute="bottom" constant="25" id="dJG-YO-lJw"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="ryl-eW-WfL"/>
                     </view>
                 </viewController>

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -73,6 +73,7 @@ class FoodEntryViewController: UIViewController {
         print("🍞 Carbs: \(carbsTextField.text)")
         print("🍞 Fat: \(fatTextField.text)")
         self.view.endEditing(true)
+        /// TODO: alert: "Food Entry Saved!"
     }
 }
 

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -1,0 +1,30 @@
+//
+//  FoodEntryViewController.swift
+//  GetFed
+//
+//  Created by Britney Smith on 12/4/18.
+//  Copyright © 2018 Britney Smith. All rights reserved.
+//
+
+import UIKit
+
+class FoodEntryViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -20,11 +20,21 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        setTextFieldPlaceholderText()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.isNavigationBarHidden = false
+    }
+    
+    // MARK - Methods
+    func setTextFieldPlaceholderText() {
+        foodTextField.placeholder = "ex: \"cookies\""
+        brandTextField.placeholder = "ex: \"Cookies Inc\""
+        proteinTextField.placeholder = "ex: \"5\""
+        carbsTextField.placeholder = "ex: \"35\""
+        fatTextField.placeholder = "ex: \"15\""
     }
 
     // MARK - Actions
@@ -33,6 +43,11 @@ class FoodEntryViewController: UIViewController {
     }
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {
+        print("🍞 Food: \(foodTextField.text)")
+        print("🍞 Brand: \(brandTextField.text)")
+        print("🍞 Protein: \(proteinTextField.text)")
+        print("🍞 Carbs: \(carbsTextField.text)")
+        print("🍞 Fat: \(fatTextField.text)")
     }
     
     

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -21,12 +21,10 @@ class FoodEntryViewController: UIViewController {
     @IBOutlet var proteinLabel: UILabel!
     @IBOutlet var carbsLabel: UILabel!
     @IBOutlet var fatLabel: UILabel!
-    @IBOutlet var scrollView: UIScrollView!
     
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        //scrollView.contentSize = CGSize(width: self.view.frame.width, height: self.view.frame.height + 100)
         setTextFieldPlaceholderText()
         setLabelText()
         setKeyboardTypes()

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -25,7 +25,6 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        setLabelText()
         setKeyboardTypes()
     }
     
@@ -35,14 +34,6 @@ class FoodEntryViewController: UIViewController {
     }
     
     // MARK - Methods
-    func setLabelText() {
-        foodLabel.text = "Food Name:"
-        brandLabel.text = "Brand Name:"
-        proteinLabel.text = "Protein amount in grams (per 100 grams)"
-        carbsLabel.text = "Carbs amount in grams (per 100 grams)"
-        fatLabel.text = "Fat amount in grams (per 100 grams)"
-    }
-    
     func setKeyboardTypes() {
         proteinTextField.keyboardType = .decimalPad
         carbsTextField.keyboardType = .decimalPad

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -26,9 +26,10 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        scrollView.contentSize = CGSize(width: self.view.frame.width, height: self.view.frame.height + 100)
         setTextFieldPlaceholderText()
         setLabelText()
-        scrollView.contentSize = CGSize(width: self.view.frame.width, height: self.view.frame.height + 100)
+        setKeyboardTypes()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -51,6 +52,12 @@ class FoodEntryViewController: UIViewController {
         proteinLabel.text = "Protein amount in grams (per 100 grams)"
         carbsLabel.text = "Carbs amount in grams (per 100 grams)"
         fatLabel.text = "Fat amount in grams (per 100 grams)"
+    }
+    
+    func setKeyboardTypes() {
+        proteinTextField.keyboardType = .decimalPad
+        carbsTextField.keyboardType = .decimalPad
+        fatTextField.keyboardType = .decimalPad
     }
 
     // MARK - Actions

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -56,6 +56,7 @@ class FoodEntryViewController: UIViewController {
     // MARK - Actions
     @IBAction func cancelButtonTapped(_ sender: UIButton) {
         navigationController?.popViewController(animated: true)
+        self.view.endEditing(true)
     }
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {
@@ -64,7 +65,7 @@ class FoodEntryViewController: UIViewController {
         print("🍞 Protein: \(proteinTextField.text)")
         print("🍞 Carbs: \(carbsTextField.text)")
         print("🍞 Fat: \(fatTextField.text)")
+        self.view.endEditing(true)
     }
-    
-    
 }
+

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -27,6 +27,13 @@ class FoodEntryViewController: UIViewController {
         navigationController?.isNavigationBarHidden = false
     }
 
+    // MARK - Actions
+    @IBAction func cancelButtonTapped(_ sender: UIButton) {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    @IBAction func saveButtonTapped(_ sender: UIButton) {
+    }
     
     
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -26,7 +26,7 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        scrollView.contentSize = CGSize(width: self.view.frame.width, height: self.view.frame.height + 100)
+        //scrollView.contentSize = CGSize(width: self.view.frame.width, height: self.view.frame.height + 100)
         setTextFieldPlaceholderText()
         setLabelText()
         setKeyboardTypes()

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -35,7 +35,7 @@ class FoodEntryViewController: UIViewController {
     // MARK - Actions
     @IBAction func cancelButtonTapped(_ sender: UIButton) {
         navigationController?.popViewController(animated: true)
-        self.view.endEditing(true)
+        view.endEditing(true)
     }
     
     @IBAction func saveButtonTapped(_ sender: UIButton) {

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -25,7 +25,6 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        setKeyboardTypes()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -33,13 +32,6 @@ class FoodEntryViewController: UIViewController {
         navigationController?.isNavigationBarHidden = false
     }
     
-    // MARK - Methods
-    func setKeyboardTypes() {
-        proteinTextField.keyboardType = .decimalPad
-        carbsTextField.keyboardType = .decimalPad
-        fatTextField.keyboardType = .decimalPad
-    }
-
     // MARK - Actions
     @IBAction func cancelButtonTapped(_ sender: UIButton) {
         navigationController?.popViewController(animated: true)

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -21,12 +21,14 @@ class FoodEntryViewController: UIViewController {
     @IBOutlet var proteinLabel: UILabel!
     @IBOutlet var carbsLabel: UILabel!
     @IBOutlet var fatLabel: UILabel!
+    @IBOutlet var scrollView: UIScrollView!
     
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setTextFieldPlaceholderText()
         setLabelText()
+        scrollView.contentSize = CGSize(width: self.view.frame.width, height: self.view.frame.height + 100)
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -33,12 +33,12 @@ class FoodEntryViewController: UIViewController {
     }
     
     // MARK - Actions
-    @IBAction func cancelButtonTapped(_ sender: UIButton) {
+    @IBAction func cancel(_ sender: UIButton) {
         navigationController?.popViewController(animated: true)
         view.endEditing(true)
     }
     
-    @IBAction func saveButtonTapped(_ sender: UIButton) {
+    @IBAction func save(_ sender: UIButton) {
         print("🍞 Food: \(foodTextField.text)")
         print("🍞 Brand: \(brandTextField.text)")
         print("🍞 Protein: \(proteinTextField.text)")

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -16,11 +16,17 @@ class FoodEntryViewController: UIViewController {
     @IBOutlet var proteinTextField: UITextField!
     @IBOutlet var carbsTextField: UITextField!
     @IBOutlet var fatTextField: UITextField!
+    @IBOutlet var foodLabel: UILabel!
+    @IBOutlet var brandLabel: UILabel!
+    @IBOutlet var proteinLabel: UILabel!
+    @IBOutlet var carbsLabel: UILabel!
+    @IBOutlet var fatLabel: UILabel!
     
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setTextFieldPlaceholderText()
+        setLabelText()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -35,6 +41,14 @@ class FoodEntryViewController: UIViewController {
         proteinTextField.placeholder = "ex: \"5\""
         carbsTextField.placeholder = "ex: \"35\""
         fatTextField.placeholder = "ex: \"15\""
+    }
+    
+    func setLabelText() {
+        foodLabel.text = "Food Name:"
+        brandLabel.text = "Brand Name:"
+        proteinLabel.text = "Protein amount in grams (per 100 grams)"
+        carbsLabel.text = "Carbs amount in grams (per 100 grams)"
+        fatLabel.text = "Fat amount in grams (per 100 grams)"
     }
 
     // MARK - Actions

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -10,6 +10,12 @@ import UIKit
 
 class FoodEntryViewController: UIViewController {
     
+    // MARK - Outlets
+    @IBOutlet var foodTextField: UITextField!
+    @IBOutlet var brandTextField: UITextField!
+    @IBOutlet var proteinTextField: UITextField!
+    @IBOutlet var carbsTextField: UITextField!
+    @IBOutlet var fatTextField: UITextField!
     
     // MARK - Lifecycle
     override func viewDidLoad() {
@@ -21,4 +27,6 @@ class FoodEntryViewController: UIViewController {
         navigationController?.isNavigationBarHidden = false
     }
 
+    
+    
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -25,7 +25,6 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        setTextFieldPlaceholderText()
         setLabelText()
         setKeyboardTypes()
     }
@@ -36,14 +35,6 @@ class FoodEntryViewController: UIViewController {
     }
     
     // MARK - Methods
-    func setTextFieldPlaceholderText() {
-        foodTextField.placeholder = "ex: \"cookies\""
-        brandTextField.placeholder = "ex: \"Cookies Inc\""
-        proteinTextField.placeholder = "ex: \"5\""
-        carbsTextField.placeholder = "ex: \"35\""
-        fatTextField.placeholder = "ex: \"15\""
-    }
-    
     func setLabelText() {
         foodLabel.text = "Food Name:"
         brandLabel.text = "Brand Name:"
@@ -70,7 +61,7 @@ class FoodEntryViewController: UIViewController {
         print("🍞 Protein: \(proteinTextField.text)")
         print("🍞 Carbs: \(carbsTextField.text)")
         print("🍞 Fat: \(fatTextField.text)")
-        self.view.endEditing(true)
+        view.endEditing(true)
         /// TODO: alert: "Food Entry Saved!"
     }
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -9,22 +9,16 @@
 import UIKit
 
 class FoodEntryViewController: UIViewController {
-
+    
+    
+    // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = false
     }
-    */
 
 }


### PR DESCRIPTION
## What you did :question:
- Created Food Entry view to enable users to enter custom food entries
- Installed Core Data

## How you did it :white_check_mark:
- Used stack views to organize the UI labels and textfields for the Food Entry view
- Added scroll view (in anticipation of adding and Image view/other entry fields in the future)
- Set the keyboard type for the protein, carbs, and fat textfields to decimal pad (may revisit since this keyboard has no return button) **UPDATE: Decimal Pad changed to Number Pad**


## How to test it :microscope:
- Run the app
- Tap 'Food Entry'
- Note that the Food Entry view is visible
- Enter any values into the textfields (with numeric entries for protein, carbs, and fat)
- Note that the alphabetical keyboard appears when the 'Food Name' and 'Brand Name' textfields are selected, and the numeric keyboard appears when the 'Protein', 'Carbs', and 'Fat' textfields are highlighted (according to Simulator keyboard settings)
- Tap the Save button
- Note that the keyboard is dismissed from the screen and the entries print to the terminal
- Tap any textfield, and tap the Cancel button
- Note that any keyboard is dismissed, and the user is returned to the Home view


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-12-06 at 09 23 00](https://user-images.githubusercontent.com/8409475/49590754-a49d6d00-f93a-11e8-9a4d-ea6c12d8ea60.png)
![simulator screen shot - iphone xr - 2018-12-06 at 09 23 06](https://user-images.githubusercontent.com/8409475/49590762-a9fab780-f93a-11e8-9335-03c7fc44e13b.png)
![simulator screen shot - iphone xr - 2018-12-06 at 09 30 30](https://user-images.githubusercontent.com/8409475/49590771-af580200-f93a-11e8-929f-19337ebc7a2b.png)
![simulator screen shot - iphone xr - 2018-12-06 at 09 30 46](https://user-images.githubusercontent.com/8409475/49590783-b67f1000-f93a-11e8-8ae8-2fe7924e08a8.png)
![screen shot 2018-12-06 at 9 31 11 am](https://user-images.githubusercontent.com/8409475/49590794-bed74b00-f93a-11e8-8e21-e45b3a1ceaef.png)
##
**UPDATE: Decimal pad changed to Number Pad**
![simulator screen shot - iphone xr - 2018-12-06 at 15 28 35](https://user-images.githubusercontent.com/8409475/49611197-cdd7f080-f96e-11e8-9754-1ca0bc8ad5c9.png)
