### PR TITLE
Custom textfields

### DIFF
--- a/GetFed/GetFed.xcodeproj/project.pbxproj
+++ b/GetFed/GetFed.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		06FF832521B1981D0066424C /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 06FF832421B1981D0066424C /* Colors.xcassets */; };
 		06FF832821B6C1260066424C /* GetFed.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 06FF832621B6C1260066424C /* GetFed.xcdatamodeld */; };
 		06FF834B21B6D4010066424C /* FoodEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF834A21B6D4010066424C /* FoodEntryViewController.swift */; };
+		06FF834D21BB03660066424C /* CustomTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FF834C21BB03660066424C /* CustomTextField.swift */; };
 		4EBFAFE8A5DF71DB25281C1F /* Pods_GetFed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B47EB7B8A39DA18E491DD2D1 /* Pods_GetFed.framework */; };
 /* End PBXBuildFile section */
 
@@ -49,6 +50,7 @@
 		06FF832421B1981D0066424C /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		06FF832721B6C1260066424C /* GetFed.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = GetFed.xcdatamodel; sourceTree = "<group>"; };
 		06FF834A21B6D4010066424C /* FoodEntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodEntryViewController.swift; sourceTree = "<group>"; };
+		06FF834C21BB03660066424C /* CustomTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTextField.swift; sourceTree = "<group>"; };
 		27E1F1A676CD7A4435C6EB69 /* Pods-GetFed.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetFed.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GetFed/Pods-GetFed.debug.xcconfig"; sourceTree = "<group>"; };
 		B47EB7B8A39DA18E491DD2D1 /* Pods_GetFed.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetFed.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CDF8590CD873BED214503BF2 /* Pods-GetFed.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetFed.release.xcconfig"; path = "Pods/Target Support Files/Pods-GetFed/Pods-GetFed.release.xcconfig"; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 				0663B1C121A347FD000B2754 /* APIClient.swift */,
 				06FF832021AEF3810066424C /* CustomColorTemplate.swift */,
 				06FF832221AEF8420066424C /* CustomValueFormatter.swift */,
+				06FF834C21BB03660066424C /* CustomTextField.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				06FF834D21BB03660066424C /* CustomTextField.swift in Sources */,
 				0663B1C821AC8F58000B2754 /* FoodDetailViewController.swift in Sources */,
 				06FF832121AEF3810066424C /* CustomColorTemplate.swift in Sources */,
 				06FF832821B6C1260066424C /* GetFed.xcdatamodeld in Sources */,

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -118,7 +118,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;cookies&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;cookies&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
@@ -141,7 +141,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;Cookies Inc&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;Cookies Inc&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
@@ -165,7 +165,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;5&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;5&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
@@ -189,7 +189,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;35&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;35&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
@@ -213,7 +213,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;15&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;15&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -109,13 +109,13 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Tbo-Gj-lit">
                                                                 <rect key="frame" x="0.0" y="0.0" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Food Name:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Food Name:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vzV-UP-cyX">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="8Y7-nS-iJI"/>
                                                                         </constraints>
-                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <color key="textColor" name="AccentColorA"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;cookies&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
@@ -132,13 +132,13 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RDL-df-qcQ">
                                                                 <rect key="frame" x="0.0" y="76" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Brand Name:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Brand Name:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SIW-Kn-UL9">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="Ze7-pT-ssH"/>
                                                                         </constraints>
-                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <color key="textColor" name="AccentColorA"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;Cookies Inc&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
@@ -156,13 +156,13 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fWT-HG-CMv">
                                                                 <rect key="frame" x="0.0" y="152" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Protein amount in grams (per 100 grams)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Protein amount in grams (per 100 grams):" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wMr-lm-Wwn">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="eig-vB-u3t"/>
                                                                         </constraints>
-                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <color key="textColor" name="AccentColorA"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;5&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
@@ -180,13 +180,13 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EAC-nU-VJP">
                                                                 <rect key="frame" x="0.0" y="228" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs amount in grams (per 100 grams)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Carbs amount in grams (per 100 grams):" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzu-iU-PFb">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="WPf-eI-E9H"/>
                                                                         </constraints>
-                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <color key="textColor" name="AccentColorA"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;35&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
@@ -204,13 +204,13 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="q5T-mK-HsP">
                                                                 <rect key="frame" x="0.0" y="304" width="325" height="61"/>
                                                                 <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fat amount in grams (per 100 grams)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fat amount in grams (per 100 grams):" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XA0-5V-DVR">
                                                                         <rect key="frame" x="0.0" y="0.0" width="325" height="25"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="25" id="m8i-jo-HzN"/>
                                                                         </constraints>
-                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                        <nil key="textColor"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <color key="textColor" name="AccentColorA"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;15&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk" customClass="CustomTextField" customModule="GetFed" customModuleProvider="target">
@@ -447,6 +447,9 @@
         </scene>
     </scenes>
     <resources>
+        <namedColor name="AccentColorA">
+            <color red="0.37599998712539673" green="0.065999999642372131" blue="0.32499998807907104" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <namedColor name="CarbsColor">
             <color red="0.0099999997764825821" green="0.99000000953674316" blue="0.73000001907348633" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>

--- a/GetFed/GetFed/Base.lproj/Main.storyboard
+++ b/GetFed/GetFed/Base.lproj/Main.storyboard
@@ -118,7 +118,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;cookies&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;cookies&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="M1y-0Q-NCC">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="m5O-Jd-EK7"/>
@@ -141,7 +141,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;Cookies Inc&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;Cookies Inc&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jnd-X3-13o">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="LpL-CP-qbi"/>
@@ -165,7 +165,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;5&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;5&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MWS-Hp-BmK">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="rfw-Az-pje"/>
@@ -189,7 +189,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;35&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;35&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="KtU-NS-OKS">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="6ql-6T-W3M"/>
@@ -213,7 +213,7 @@
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
-                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ex: &quot;15&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
+                                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ex: &quot;15&quot;" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gvS-7T-Fnk">
                                                                         <rect key="frame" x="0.0" y="25" width="325" height="36"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="36" id="gUe-Xj-eNJ"/>
@@ -346,41 +346,41 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodNameLabel" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jXi-uR-aoY">
-                                        <rect key="frame" x="76" y="0.0" width="223.5" height="95.5"/>
+                                        <rect key="frame" x="76" y="0.0" width="223.5" height="57"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="28"/>
                                         <color key="textColor" red="0.37506285919999999" green="0.066743286639999996" blue="0.32412731210000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="brandNameLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hW6-qa-hZr">
-                                        <rect key="frame" x="122" y="95.5" width="131.5" height="68.5"/>
+                                        <rect key="frame" x="122" y="57" width="131.5" height="40.5"/>
                                         <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                         <color key="textColor" red="0.43968416960000001" green="0.44130747129999998" blue="0.41126847030000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aDn-XM-Q4W" customClass="PieChartView" customModule="Charts">
-                                        <rect key="frame" x="30" y="164" width="315" height="171"/>
+                                        <rect key="frame" x="30" y="97.5" width="315" height="0.0"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" id="3hB-x6-O7e"/>
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Dga-vQ-3Df">
-                                        <rect key="frame" x="50" y="335" width="275" height="196.5"/>
+                                        <rect key="frame" x="50" y="97.5" width="275" height="116.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="proteinLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cf6-t2-S3O">
-                                                <rect key="frame" x="0.0" y="69.5" width="265" height="57.5"/>
+                                                <rect key="frame" x="0.0" y="29.5" width="265" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="ProteinColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="carbsLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xgo-Yg-tdL">
-                                                <rect key="frame" x="270" y="69.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="270" y="29.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="CarbsColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="fatLabel" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n6g-er-nys">
-                                                <rect key="frame" x="275" y="69.5" width="0.0" height="57.5"/>
+                                                <rect key="frame" x="275" y="29.5" width="0.0" height="57.5"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue-Bold" family="Helvetica Neue" pointSize="48"/>
                                                 <color key="textColor" name="FatColor"/>
                                                 <nil key="highlightedColor"/>
@@ -388,7 +388,7 @@
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="caloriesLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hJc-Io-5qD">
-                                        <rect key="frame" x="116.5" y="531.5" width="142" height="71.5"/>
+                                        <rect key="frame" x="116.5" y="214" width="142" height="389"/>
                                         <fontDescription key="fontDescription" name="Rockwell-Regular" family="Rockwell" pointSize="21"/>
                                         <color key="textColor" red="0.0062921650150000001" green="0.37506285919999999" blue="0.028588568389999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>

--- a/GetFed/GetFed/Colors.xcassets/AccentColorA.colorset/Contents.json
+++ b/GetFed/GetFed/Colors.xcassets/AccentColorA.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.376",
+          "alpha" : "1.000",
+          "blue" : "0.325",
+          "green" : "0.066"
+        }
+      }
+    }
+  ]
+}

--- a/GetFed/GetFed/Colors.xcassets/AccentColorB.colorset/Contents.json
+++ b/GetFed/GetFed/Colors.xcassets/AccentColorB.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  },
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.008",
+          "alpha" : "1.000",
+          "blue" : "0.027",
+          "green" : "0.376"
+        }
+      }
+    }
+  ]
+}

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -25,6 +25,11 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        foodTextField.underlined()
+        brandTextField.underlined()
+        proteinTextField.underlined()
+        carbsTextField.underlined()
+        fatTextField.underlined()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -11,11 +11,11 @@ import UIKit
 class FoodEntryViewController: UIViewController {
     
     // MARK - Outlets
-    @IBOutlet var foodTextField: UITextField!
-    @IBOutlet var brandTextField: UITextField!
-    @IBOutlet var proteinTextField: UITextField!
-    @IBOutlet var carbsTextField: UITextField!
-    @IBOutlet var fatTextField: UITextField!
+    @IBOutlet var foodTextField: CustomTextField!
+    @IBOutlet var brandTextField: CustomTextField!
+    @IBOutlet var proteinTextField: CustomTextField!
+    @IBOutlet var carbsTextField: CustomTextField!
+    @IBOutlet var fatTextField: CustomTextField!
     @IBOutlet var foodLabel: UILabel!
     @IBOutlet var brandLabel: UILabel!
     @IBOutlet var proteinLabel: UILabel!
@@ -25,11 +25,6 @@ class FoodEntryViewController: UIViewController {
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        foodTextField.underlined()
-        brandTextField.underlined()
-        proteinTextField.underlined()
-        carbsTextField.underlined()
-        fatTextField.underlined()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/GetFed/GetFed/Helpers/CustomTextField.swift
+++ b/GetFed/GetFed/Helpers/CustomTextField.swift
@@ -19,10 +19,8 @@ class CustomTextField: UITextField {
     func underline() {
         let border = CALayer()
         let width = CGFloat(1.25)
-        guard let customBorderColor = UIColor(named: ColorID.AccentColorB.rawValue) else {
-            print("No border color!")
-            return
-        }
+        let customBorderColor = UIColor(named: ColorID.AccentColorB.rawValue) ?? UIColor.black
+        
         border.borderColor = customBorderColor.cgColor
         border.frame = CGRect(x: 0, y: self.frame.size.height - width, width: self.frame.size.width, height: self.frame.size.height)
         border.borderWidth = width

--- a/GetFed/GetFed/Helpers/CustomTextField.swift
+++ b/GetFed/GetFed/Helpers/CustomTextField.swift
@@ -1,0 +1,23 @@
+//
+//  CustomTextField.swift
+//  GetFed
+//
+//  Created by Britney Smith on 12/7/18.
+//  Copyright © 2018 Britney Smith. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UITextField {
+    func underlined() {
+        let border = CALayer()
+        let width = CGFloat(1.0)
+        
+        border.borderColor = UIColor.lightGray.cgColor
+        border.frame = CGRect(x: 0, y: self.frame.size.height - width, width: self.frame.size.width, height: self.frame.size.height)
+        border.borderWidth = width
+        self.layer.addSublayer(border)
+        self.layer.masksToBounds = true
+    }
+}

--- a/GetFed/GetFed/Helpers/CustomTextField.swift
+++ b/GetFed/GetFed/Helpers/CustomTextField.swift
@@ -18,9 +18,12 @@ class CustomTextField: UITextField {
     
     func underline() {
         let border = CALayer()
-        let width = CGFloat(1.0)
-        
-        border.borderColor = UIColor.lightGray.cgColor
+        let width = CGFloat(1.25)
+        guard let customBorderColor = UIColor(named: ColorID.AccentColorB.rawValue) else {
+            print("No border color!")
+            return
+        }
+        border.borderColor = customBorderColor.cgColor
         border.frame = CGRect(x: 0, y: self.frame.size.height - width, width: self.frame.size.width, height: self.frame.size.height)
         border.borderWidth = width
         self.layer.addSublayer(border)

--- a/GetFed/GetFed/Helpers/CustomTextField.swift
+++ b/GetFed/GetFed/Helpers/CustomTextField.swift
@@ -9,8 +9,14 @@
 import Foundation
 import UIKit
 
-extension UITextField {
-    func underlined() {
+class CustomTextField: UITextField {
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        underline()
+    }
+    
+    func underline() {
         let border = CALayer()
         let width = CGFloat(1.0)
         

--- a/GetFed/GetFed/Helpers/Identity.swift
+++ b/GetFed/GetFed/Helpers/Identity.swift
@@ -22,4 +22,6 @@ enum ColorID: String {
     case ProteinColor
     case CarbsColor
     case FatColor
+    case AccentColorA
+    case AccentColorB
 }

--- a/GetFed/GetFed/Info.plist
+++ b/GetFed/GetFed/Info.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+        <key>api.edamam.com</key>
+        <dict>
+            <key>NSExceptionRequiresForwardSecrecy</key>
+            <false/>  
+        </dict>
+    </dict>
+</dict>
+</dict>
+</plist>

--- a/GetFed/Podfile
+++ b/GetFed/Podfile
@@ -1,0 +1,12 @@
+# Uncomment the next line to define a global platform for your project
+# platform :ios, '12.1'
+
+target 'GetFed' do
+  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
+  use_frameworks!
+
+  # Pods for GetFed
+  pod 'Alamofire', '~> 4.7'
+  pod 'Charts'
+
+end


### PR DESCRIPTION
## What you did :question:
- Styled textfields in Food Entry screen to only include bottom border
- Added more styling to Food Entry labels
**UPDATE 12-10-18: Added Podfile and Info.plist**

## How you did it :white_check_mark:
- Added textfield border layer in custom subclass
- Added dark purple and dark green as Color Assets to Color.xcassets folder
- Added cases for new color assets in enum ColorID
- Styled Food Entry labels in Interface Builder


## How to test it :microscope:
- Run the app
- Tap 'Food Entry'
- Note that the labels should appear dark purple and bolded, and the textfields should appear as dark green bottom borders


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-12-07 at 15 41 24](https://user-images.githubusercontent.com/8409475/49671882-59b54f80-fa37-11e8-81ac-3f4bb4eaf185.png)
