### PR TITLE
Added workspace

### DIFF
--- a/GetFed/GetFed.xcodeproj/project.pbxproj
+++ b/GetFed/GetFed.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		063B920921BEBC1500318D62 /* Constants-example.swift in Sources */ = {isa = PBXBuildFile; fileRef = 063B920821BEBC1500318D62 /* Constants-example.swift */; };
 		0663B19D219F496E000B2754 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0663B19C219F496E000B2754 /* AppDelegate.swift */; };
 		0663B1A2219F496E000B2754 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0663B1A0219F496E000B2754 /* Main.storyboard */; };
 		0663B1A4219F4970000B2754 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0663B1A3219F4970000B2754 /* Assets.xcassets */; };
@@ -30,6 +31,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		063B920821BEBC1500318D62 /* Constants-example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constants-example.swift"; sourceTree = "<group>"; };
 		0663B199219F496E000B2754 /* GetFed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GetFed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0663B19C219F496E000B2754 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0663B1A1219F496E000B2754 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 				06FF832021AEF3810066424C /* CustomColorTemplate.swift */,
 				06FF832221AEF8420066424C /* CustomValueFormatter.swift */,
 				06FF834C21BB03660066424C /* CustomTextField.swift */,
+				063B920821BEBC1500318D62 /* Constants-example.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -290,6 +293,7 @@
 				0663B1C821AC8F58000B2754 /* FoodDetailViewController.swift in Sources */,
 				06FF832121AEF3810066424C /* CustomColorTemplate.swift in Sources */,
 				06FF832821B6C1260066424C /* GetFed.xcdatamodeld in Sources */,
+				063B920921BEBC1500318D62 /* Constants-example.swift in Sources */,
 				0663B19D219F496E000B2754 /* AppDelegate.swift in Sources */,
 				06FF834B21B6D4010066424C /* FoodEntryViewController.swift in Sources */,
 				0663B1B5219F6A64000B2754 /* Identity.swift in Sources */,

--- a/GetFed/GetFed.xcworkspace/contents.xcworkspacedata
+++ b/GetFed/GetFed.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:GetFed.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/GetFed/GetFed.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/GetFed/GetFed.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/GetFed/GetFed/Helpers/Constants-example.swift
+++ b/GetFed/GetFed/Helpers/Constants-example.swift
@@ -1,0 +1,13 @@
+//
+//  Constants-example.swift
+//  GetFed
+//
+//  Created by Britney Smith on 12/10/18.
+//  Copyright © 2018 Britney Smith. All rights reserved.
+//
+
+import Foundation
+
+/// Replace with app key and app id from developer account (for the Food API) at https://www.edamam.com
+let EdamamAppID = "your-app-id"
+let EdamamAppKey = "your-app-key"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # GetFed
+
+## Project Setup
+
+- After cloning, navigate to directory `GetFed/GetFed` and run `pod install`
+
+## Opening the project and running the app
+
+- Open a free developer account (for the Food API) at https://www.edamam.com
+
+- In XCode, open the `GetFed.xcworkspace` file
+
+- In the `Constants-example.swift` file, replace the values for `EdamamAppID` and `EdamamAppKey` with those provided with the Edamam developer account, found in the Dashboard. The Application ID and Application Key that come with the initial 'API Signup' sample app should be fine to use.
+
+- Change the name of this file to `Constants.swift`
+
+- App should be ready to run!

--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
 ## Opening the project and running the app
 
 - Open a free developer account (for the Food API) at https://www.edamam.com
-
 - In XCode, open the `GetFed.xcworkspace` file
-
 - In the `Constants-example.swift` file, replace the values for `EdamamAppID` and `EdamamAppKey` with those provided with the Edamam developer account, found in the Dashboard. The Application ID and Application Key that come with the initial 'API Signup' sample app should be fine to use.
-
 - Change the name of this file to `Constants.swift`
-
 - App should be ready to run!


### PR DESCRIPTION
## What you did :question:
- Staged and committed `GetFed.xcworkspace/` directory to fix cocoapods error when opening from cloned project (previously added Podfile in PR `custom-textfields`

## How you did it :white_check_mark:
`git add "GetFed/GetFed.xcworkspace"`


## How to test it :microscope:
- Clone project
- In Terminal: navigate to directory `GetFed/GetFed`
- In Terminal: enter `git checkout add-workspace`
- In Terminal: enter `pod install`
- Note that the installed pod status should include:
```
Installing Alamofire (4.7.3)
Installing Charts (3.2.1)
```
(version numbers may very depending on clone date)
- In either the Terminal or Finder, open the `GetFed.xcworkspace` file in XCode
- Note that the project should open with no errors
- **UPDATE 2: Remove old 'Constants.swift' file in 'Helpers' directory of the project.**

**UPDATE: Added instructions (also in README):***
- Open a free developer account (for the Food API) at https://www.edamam.com
- In the `Constants-example.swift` file, replace the values for `EdamamAppID` and `EdamamAppKey` with those provided with the Edamam developer account, found in the Dashboard. The Application ID and Application Key that come with the initial 'API Signup' sample app should be fine to use.
- Change the name of this file to `Constants.swift`
- App should be ready to run!

## Screenshots (if applicable) :camera:
N/A (unless reviewers would appreciate some)