### PR TITLE
Core data

### DIFF
--- a/GetFed/GetFed.xcodeproj/project.pbxproj
+++ b/GetFed/GetFed.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0644A0B121C16AEF00229DAF /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0644A0B021C16AEF00229DAF /* CoreDataManager.swift */; };
 		0663B19D219F496E000B2754 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0663B19C219F496E000B2754 /* AppDelegate.swift */; };
 		0663B1A2219F496E000B2754 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0663B1A0219F496E000B2754 /* Main.storyboard */; };
 		0663B1A4219F4970000B2754 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0663B1A3219F4970000B2754 /* Assets.xcassets */; };
@@ -30,6 +31,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0644A0B021C16AEF00229DAF /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		0663B199219F496E000B2754 /* GetFed.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GetFed.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0663B19C219F496E000B2754 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0663B1A1219F496E000B2754 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 				06FF832021AEF3810066424C /* CustomColorTemplate.swift */,
 				06FF832221AEF8420066424C /* CustomValueFormatter.swift */,
 				06FF834C21BB03660066424C /* CustomTextField.swift */,
+				0644A0B021C16AEF00229DAF /* CoreDataManager.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -289,6 +292,7 @@
 				06FF834D21BB03660066424C /* CustomTextField.swift in Sources */,
 				0663B1C821AC8F58000B2754 /* FoodDetailViewController.swift in Sources */,
 				06FF832121AEF3810066424C /* CustomColorTemplate.swift in Sources */,
+				0644A0B121C16AEF00229DAF /* CoreDataManager.swift in Sources */,
 				06FF832821B6C1260066424C /* GetFed.xcdatamodeld in Sources */,
 				0663B19D219F496E000B2754 /* AppDelegate.swift in Sources */,
 				06FF834B21B6D4010066424C /* FoodEntryViewController.swift in Sources */,

--- a/GetFed/GetFed/AppDelegate.swift
+++ b/GetFed/GetFed/AppDelegate.swift
@@ -27,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-        //self.saveContext()
+        CoreDataManager.sharedManager.saveContext()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
@@ -41,7 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
         // Saves changes in the application's managed object context before the application terminates.
-        //self.saveContext()
+        CoreDataManager.sharedManager.saveContext()
     }
 }
 

--- a/GetFed/GetFed/AppDelegate.swift
+++ b/GetFed/GetFed/AppDelegate.swift
@@ -7,7 +7,6 @@
 //
 
 import UIKit
-import CoreData
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -28,7 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-        self.saveContext()
+        //self.saveContext()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
@@ -42,54 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
         // Saves changes in the application's managed object context before the application terminates.
-        self.saveContext()
+        //self.saveContext()
     }
-
-    // MARK: - Core Data stack
-    
-    lazy var persistentContainer: NSPersistentContainer = {
-        /*
-         The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail.
-         */
-        let container = NSPersistentContainer(name: "GetFed")
-        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                
-                /*
-                 Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was.
-                 */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-        })
-        return container
-    }()
-    
-    // MARK: - Core Data Saving support
-    
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-
-
 }
 

--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -43,7 +43,7 @@ class FoodDetailViewController: UIViewController {
         if let food = food {
             let nutrients = food.nutrients
             let foodName = food.label
-            
+
             foodNameLabel.text = foodName
             
             if let brandName = food.brand {
@@ -53,26 +53,25 @@ class FoodDetailViewController: UIViewController {
             }
             
             if let calories = nutrients.calories {
-                let caloriesString = String(format: "%.0f", calories)
-                caloriesLabel.text = "Calories: \(caloriesString)"
+                caloriesLabel.text = "Calories: \(Int(truncating: calories))"
             } else {
                 caloriesLabel.text = "No calorie data"
             }
             
             if let protein = nutrients.protein {
-                proteinLabel.text = "\(Int(protein))g"
+                proteinLabel.text = "\(Int(truncating: protein))g"
             } else {
                 proteinLabel.isHidden = true
             }
             
             if let carbs = nutrients.carbs {
-                carbsLabel.text = "\(Int(carbs))g"
+                carbsLabel.text = "\(Int(truncating: carbs))g"
             } else {
                 carbsLabel.isHidden = true
             }
             
             if let fat = nutrients.fat {
-                fatLabel.text = "\(Int(fat))g"
+                fatLabel.text = "\(Int(truncating: fat))g"
             } else {
                 fatLabel.isHidden = true
             }

--- a/GetFed/GetFed/Controllers/FoodDetailViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodDetailViewController.swift
@@ -115,9 +115,9 @@ extension FoodDetailViewController {
             return nil
         }
         
-        let entryOne = PieChartDataEntry(value: proteinData, label: "Protein")
-        let entryTwo = PieChartDataEntry(value: carbsData, label: "Carbs")
-        let entryThree = PieChartDataEntry(value: fatData, label: "Fat")
+        let entryOne = PieChartDataEntry(value: Double(truncating: proteinData), label: "Protein")
+        let entryTwo = PieChartDataEntry(value: Double(truncating: carbsData), label: "Carbs")
+        let entryThree = PieChartDataEntry(value: Double(truncating: fatData), label: "Fat")
         let dataEntries = [entryOne, entryTwo, entryThree]
         
         let dataSet = PieChartDataSet(values: dataEntries, label: "per 100 grams")

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -38,7 +38,7 @@ class FoodEntryViewController: UIViewController {
     
     // MARK - Methods
     func savedRecordAlert() {
-        let successAlert = UIAlertController(title: "Success!", message: "New food entry was saved successfully!", preferredStyle: .alert)
+        let successAlert = UIAlertController(title: "Success!", message: "New food entry for \"\(foodTextField.text!)\" was saved successfully!", preferredStyle: .alert)
         successAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         self.present(successAlert, animated: true, completion: nil)
     }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -43,6 +43,7 @@ class FoodEntryViewController: UIViewController {
         print("🍞 Carbs: \(carbsTextField.text)")
         print("🍞 Fat: \(fatTextField.text)")
         view.endEditing(true)
+        createManagedObjectModel()
         /// TODO: alert: "Food Entry Saved!"
     }
 }
@@ -74,5 +75,9 @@ extension FoodEntryViewController {
         } catch {
             print("Save error: \(error)")
         }
+    }
+    
+    func readRecords() {
+        
     }
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -36,6 +36,19 @@ class FoodEntryViewController: UIViewController {
         navigationController?.isNavigationBarHidden = false
     }
     
+    // MARK - Methods
+    func savedRecordAlert() {
+        let successAlert = UIAlertController(title: "Success!", message: "New food entry was saved successfully!", preferredStyle: .alert)
+        successAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        self.present(successAlert, animated: true, completion: nil)
+    }
+    
+    func failedSaveRecordAlert() {
+        let failureAlert = UIAlertController(title: "Uh oh!", message: "Error when saving new food entry.", preferredStyle: .alert)
+        failureAlert.addAction(UIAlertAction(title: "Try Again", style: .cancel, handler: nil))
+        self.present(failureAlert, animated: true, completion: nil)
+    }
+    
     // MARK - Actions
     @IBAction func cancel(_ sender: UIButton) {
         navigationController?.popViewController(animated: true)
@@ -52,7 +65,6 @@ class FoodEntryViewController: UIViewController {
         view.endEditing(true)
         saveNewFood()
         readRecords()
-        /// TODO: alert: "Food Entry Saved!"
     }
 }
 
@@ -95,7 +107,9 @@ extension FoodEntryViewController {
         
         do {
             try managedContext.save()
+            savedRecordAlert()
         } catch {
+            failedSaveRecordAlert()
             print("Save error: \(error)")
         }
     }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -19,9 +19,6 @@ class FoodEntryViewController: UIViewController {
     @IBOutlet var carbsTextField: CustomTextField!
     @IBOutlet var fatTextField: CustomTextField!
     
-    // MARK - Properties
-    var foodRecords: [Food] = []
-    
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -69,7 +66,6 @@ class FoodEntryViewController: UIViewController {
         print("🍞 Fat: \(fatTextField.text)")
         view.endEditing(true)
         saveNewFood()
-        readRecords()
     }
 }
 
@@ -77,58 +73,23 @@ class FoodEntryViewController: UIViewController {
 extension FoodEntryViewController {
     
     func saveNewFood() {
-//        guard let foodEntity = NSEntityDescription.entity(forEntityName: "Food", in: managedContext) else { return }
-//        guard let nutrientsEntity = NSEntityDescription.entity(forEntityName: "Nutrients", in: managedContext) else { return }
-//
-//        let enteredFood = NSManagedObject(entity: foodEntity, insertInto: managedContext)
-//        let enteredNutrients = NSManagedObject(entity: nutrientsEntity, insertInto: managedContext)
         
-//        enteredFood.setValue(foodTextField.text, forKey: "label")
-//        enteredFood.setValue(brandTextField.text, forKey: "brand")
-        
-        guard let caloriesValue = caloriesTextField.text,
-              let proteinValue = proteinTextField.text,
-              let carbsValue = carbsTextField.text,
-              let fatValue = fatTextField.text
+        guard let foodLabel = foodTextField.text,
+              let brand = brandTextField.text,
+              let caloriesValue = Double(caloriesTextField.text ?? ""),
+              let proteinValue = Double(proteinTextField.text ?? ""),
+              let carbsValue = Double(carbsTextField.text ?? ""),
+              let fatValue = Double(fatTextField.text ?? "")
             else { return }
         
-//        if let caloriesInt = Int(caloriesValue) {
-//            enteredNutrients.setValue(NSNumber(value: caloriesInt), forKey: "calories")
-//        }
-//        
-//        if let proteinInt = Int(proteinValue) {
-//            enteredNutrients.setValue(NSNumber(value: proteinInt), forKey: "protein")
-//        }
-//        
-//        if let carbsInt = Int(carbsValue) {
-//            enteredNutrients.setValue(NSNumber(value: carbsInt), forKey: "carbs")
-//        }
-//        
-//        if let fatInt = Int(fatValue) {
-//            enteredNutrients.setValue(NSNumber(value: fatInt), forKey: "fat")
-//        }
-//        
-//        enteredFood.setValue(enteredNutrients, forKey: "nutrients")
+        CoreDataManager.sharedManager.insertNewFood(label: foodLabel, brand: brand, calories: caloriesValue, protein: proteinValue, carbs: carbsValue, fat: fatValue)
         
-        do {
-            try managedContext.save()
+        if CoreDataManager.sharedManager.isSaved == true {
             savedRecordAlert()
             clearTextFields()
-        } catch {
+            CoreDataManager.sharedManager.fetchAllRecords()
+        } else {
             failedSaveRecordAlert()
-            print("Save error: \(error)")
-        }
-    }
-    /// temporary method for testing purposes
-    func readRecords() {
-        let foodFetch = NSFetchRequest<NSFetchRequestResult>(entityName: "Food")
-        do {
-            foodRecords = try managedContext.fetch(foodFetch) as! [Food]
-            for record in foodRecords {
-                print("🍎 Food record: \(record.label), \(record.nutrients.calories)")
-            }
-        } catch {
-            print("Fetch error: \(error)")
         }
     }
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -75,6 +75,14 @@ extension FoodEntryViewController {
         } catch {
             print("Save error: \(error)")
         }
+        
+        let foodFetch = NSFetchRequest<NSFetchRequestResult>(entityName: "Food")
+        var foodRecords = [Food]()
+        do {
+            foodRecords = try managedContext.execute(foodFetch)
+        } catch {
+            print("Fetch error: \(error)")
+        }
     }
     
     func readRecords() {

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -51,7 +51,22 @@ class FoodEntryViewController: UIViewController {
 extension FoodEntryViewController {
     
     func createManagedObjectModel() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return } /// fatalerror
+        let managedContext = appDelegate.persistentContainer.viewContext
+        guard let foodEntity = NSEntityDescription.entity(forEntityName: "Food", in: managedContext) else { return }
+        guard let nutrientsEntity = NSEntityDescription.entity(forEntityName: "Nutrients", in: managedContext) else { return }
         
+        let enteredFood = NSManagedObject(entity: foodEntity, insertInto: managedContext)
+        let enteredNutrients = NSManagedObject(entity: nutrientsEntity, insertInto: managedContext)
+        
+        enteredFood.setValue(foodTextField.text, forKey: "label")
+        enteredFood.setValue(brandTextField.text, forKey: "brand")
+        
+        enteredNutrients.setValue(caloriesTextField.text, forKey: "calories")
+        enteredNutrients.setValue(proteinTextField.text, forKey: "protein")
+        enteredNutrients.setValue(carbsTextField.text, forKey: "carbs")
+        enteredNutrients.setValue(fatTextField.text, forKey: "fat")
+        
+        enteredFood.setValue(enteredNutrients, forKey: "nutrients")
     }
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -63,10 +63,27 @@ extension FoodEntryViewController {
         enteredFood.setValue(foodTextField.text, forKey: "label")
         enteredFood.setValue(brandTextField.text, forKey: "brand")
         
-        enteredNutrients.setValue(caloriesTextField.text, forKey: "calories")
-        enteredNutrients.setValue(proteinTextField.text, forKey: "protein")
-        enteredNutrients.setValue(carbsTextField.text, forKey: "carbs")
-        enteredNutrients.setValue(fatTextField.text, forKey: "fat")
+        guard let caloriesValue = caloriesTextField.text,
+              let proteinValue = proteinTextField.text,
+              let carbsValue = carbsTextField.text,
+              let fatValue = fatTextField.text
+            else { return }
+        
+        if let caloriesInt = Int(caloriesValue) {
+            enteredNutrients.setValue(NSNumber(value: caloriesInt), forKey: "calories")
+        }
+        
+        if let proteinInt = Int(proteinValue) {
+            enteredNutrients.setValue(NSNumber(value: proteinInt), forKey: "protein")
+        }
+        
+        if let carbsInt = Int(carbsValue) {
+            enteredNutrients.setValue(NSNumber(value: carbsInt), forKey: "carbs")
+        }
+        
+        if let fatInt = Int(fatValue) {
+            enteredNutrients.setValue(NSNumber(value: fatInt), forKey: "fat")
+        }
         
         enteredFood.setValue(enteredNutrients, forKey: "nutrients")
         
@@ -77,9 +94,12 @@ extension FoodEntryViewController {
         }
         
         let foodFetch = NSFetchRequest<NSFetchRequestResult>(entityName: "Food")
-        var foodRecords = [Food]()
+        var foodRecords: [Food] = []
         do {
-            foodRecords = try managedContext.execute(foodFetch)
+            foodRecords = try managedContext.fetch(foodFetch) as! [Food]
+            for record in foodRecords {
+                print("🍎 Food record: \(record.label), \(record.nutrients.calories)")
+            }
         } catch {
             print("Fetch error: \(error)")
         }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -68,5 +68,11 @@ extension FoodEntryViewController {
         enteredNutrients.setValue(fatTextField.text, forKey: "fat")
         
         enteredFood.setValue(enteredNutrients, forKey: "nutrients")
+        
+        do {
+            try managedContext.save()
+        } catch {
+            print("Save error: \(error)")
+        }
     }
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -22,8 +22,7 @@ class FoodEntryViewController: UIViewController {
     // MARK - Properties
     var foodRecords: [Food] = []
     lazy var managedContext: NSManagedObjectContext = {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { fatalError() }
-        return appDelegate.persistentContainer.viewContext
+        return CoreDataManager.sharedManager.persistentContainer.viewContext
     }()
     
     // MARK - Lifecycle

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import CoreData
 
 class FoodEntryViewController: UIViewController {
     
@@ -49,3 +50,11 @@ class FoodEntryViewController: UIViewController {
     }
 }
 
+// MARK - Core Data Management
+extension FoodEntryViewController {
+    
+    func createManagedObjectModel() {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return }
+        
+    }
+}

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -21,9 +21,6 @@ class FoodEntryViewController: UIViewController {
     
     // MARK - Properties
     var foodRecords: [Food] = []
-    lazy var managedContext: NSManagedObjectContext = {
-        return CoreDataManager.sharedManager.persistentContainer.viewContext
-    }()
     
     // MARK - Lifecycle
     override func viewDidLoad() {
@@ -80,14 +77,14 @@ class FoodEntryViewController: UIViewController {
 extension FoodEntryViewController {
     
     func saveNewFood() {
-        guard let foodEntity = NSEntityDescription.entity(forEntityName: "Food", in: managedContext) else { return }
-        guard let nutrientsEntity = NSEntityDescription.entity(forEntityName: "Nutrients", in: managedContext) else { return }
+//        guard let foodEntity = NSEntityDescription.entity(forEntityName: "Food", in: managedContext) else { return }
+//        guard let nutrientsEntity = NSEntityDescription.entity(forEntityName: "Nutrients", in: managedContext) else { return }
+//
+//        let enteredFood = NSManagedObject(entity: foodEntity, insertInto: managedContext)
+//        let enteredNutrients = NSManagedObject(entity: nutrientsEntity, insertInto: managedContext)
         
-        let enteredFood = NSManagedObject(entity: foodEntity, insertInto: managedContext)
-        let enteredNutrients = NSManagedObject(entity: nutrientsEntity, insertInto: managedContext)
-        
-        enteredFood.setValue(foodTextField.text, forKey: "label")
-        enteredFood.setValue(brandTextField.text, forKey: "brand")
+//        enteredFood.setValue(foodTextField.text, forKey: "label")
+//        enteredFood.setValue(brandTextField.text, forKey: "brand")
         
         guard let caloriesValue = caloriesTextField.text,
               let proteinValue = proteinTextField.text,
@@ -95,23 +92,23 @@ extension FoodEntryViewController {
               let fatValue = fatTextField.text
             else { return }
         
-        if let caloriesInt = Int(caloriesValue) {
-            enteredNutrients.setValue(NSNumber(value: caloriesInt), forKey: "calories")
-        }
-        
-        if let proteinInt = Int(proteinValue) {
-            enteredNutrients.setValue(NSNumber(value: proteinInt), forKey: "protein")
-        }
-        
-        if let carbsInt = Int(carbsValue) {
-            enteredNutrients.setValue(NSNumber(value: carbsInt), forKey: "carbs")
-        }
-        
-        if let fatInt = Int(fatValue) {
-            enteredNutrients.setValue(NSNumber(value: fatInt), forKey: "fat")
-        }
-        
-        enteredFood.setValue(enteredNutrients, forKey: "nutrients")
+//        if let caloriesInt = Int(caloriesValue) {
+//            enteredNutrients.setValue(NSNumber(value: caloriesInt), forKey: "calories")
+//        }
+//        
+//        if let proteinInt = Int(proteinValue) {
+//            enteredNutrients.setValue(NSNumber(value: proteinInt), forKey: "protein")
+//        }
+//        
+//        if let carbsInt = Int(carbsValue) {
+//            enteredNutrients.setValue(NSNumber(value: carbsInt), forKey: "carbs")
+//        }
+//        
+//        if let fatInt = Int(fatValue) {
+//            enteredNutrients.setValue(NSNumber(value: fatInt), forKey: "fat")
+//        }
+//        
+//        enteredFood.setValue(enteredNutrients, forKey: "nutrients")
         
         do {
             try managedContext.save()

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -49,6 +49,15 @@ class FoodEntryViewController: UIViewController {
         self.present(failureAlert, animated: true, completion: nil)
     }
     
+    func clearTextFields() {
+        foodTextField.text = nil
+        brandTextField.text = nil
+        caloriesTextField.text = nil
+        proteinTextField.text = nil
+        carbsTextField.text = nil
+        fatTextField.text = nil
+    }
+    
     // MARK - Actions
     @IBAction func cancel(_ sender: UIButton) {
         navigationController?.popViewController(animated: true)
@@ -108,6 +117,7 @@ extension FoodEntryViewController {
         do {
             try managedContext.save()
             savedRecordAlert()
+            clearTextFields()
         } catch {
             failedSaveRecordAlert()
             print("Save error: \(error)")

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -19,6 +19,13 @@ class FoodEntryViewController: UIViewController {
     @IBOutlet var carbsTextField: CustomTextField!
     @IBOutlet var fatTextField: CustomTextField!
     
+    // MARK - Properties
+    var foodRecords: [Food] = []
+    lazy var managedContext: NSManagedObjectContext = {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { fatalError() }
+        return appDelegate.persistentContainer.viewContext
+    }()
+    
     // MARK - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -43,7 +50,8 @@ class FoodEntryViewController: UIViewController {
         print("🍞 Carbs: \(carbsTextField.text)")
         print("🍞 Fat: \(fatTextField.text)")
         view.endEditing(true)
-        createManagedObjectModel()
+        saveNewFood()
+        readRecords()
         /// TODO: alert: "Food Entry Saved!"
     }
 }
@@ -51,9 +59,7 @@ class FoodEntryViewController: UIViewController {
 // MARK - Core Data Management
 extension FoodEntryViewController {
     
-    func createManagedObjectModel() {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return } /// fatalerror
-        let managedContext = appDelegate.persistentContainer.viewContext
+    func saveNewFood() {
         guard let foodEntity = NSEntityDescription.entity(forEntityName: "Food", in: managedContext) else { return }
         guard let nutrientsEntity = NSEntityDescription.entity(forEntityName: "Nutrients", in: managedContext) else { return }
         
@@ -92,9 +98,10 @@ extension FoodEntryViewController {
         } catch {
             print("Save error: \(error)")
         }
-        
+    }
+    
+    func readRecords() {
         let foodFetch = NSFetchRequest<NSFetchRequestResult>(entityName: "Food")
-        var foodRecords: [Food] = []
         do {
             foodRecords = try managedContext.fetch(foodFetch) as! [Food]
             for record in foodRecords {
@@ -103,9 +110,5 @@ extension FoodEntryViewController {
         } catch {
             print("Fetch error: \(error)")
         }
-    }
-    
-    func readRecords() {
-        
     }
 }

--- a/GetFed/GetFed/Controllers/FoodEntryViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodEntryViewController.swift
@@ -123,7 +123,7 @@ extension FoodEntryViewController {
             print("Save error: \(error)")
         }
     }
-    
+    /// temporary method for testing purposes
     func readRecords() {
         let foodFetch = NSFetchRequest<NSFetchRequestResult>(entityName: "Food")
         do {

--- a/GetFed/GetFed/Controllers/FoodSearchViewController.swift
+++ b/GetFed/GetFed/Controllers/FoodSearchViewController.swift
@@ -56,8 +56,9 @@ extension FoodSearchViewController: UITableViewDataSource, UITableViewDelegate {
             fatalError("Fatal error: No cell")
         }
         if let searchResults = searchResults {
-            cell.foodLabel.text = searchResults.results[indexPath.row].food.label
-            cell.brandLabel.text = searchResults.results[indexPath.row].food.brand
+            guard let food = searchResults.results[indexPath.row].food else { fatalError() }
+            cell.foodLabel.text = food.label
+            cell.brandLabel.text = food.brand
         } else {
             cell.foodLabel.text = "No food data"
             cell.brandLabel.isHidden = true

--- a/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
+++ b/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18B75" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="Food" representedClassName="Food" syncable="YES" codeGenerationType="class">
+    <entity name="Food" representedClassName="Food" syncable="YES">
         <attribute name="brandName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="foodName" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="nutrients" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Nutrients" syncable="YES"/>
     </entity>
-    <entity name="Nutrients" representedClassName="Nutrients" syncable="YES" codeGenerationType="class">
+    <entity name="Nutrients" representedClassName="Nutrients" syncable="YES">
+        <attribute name="calories" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="carbs" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="fat" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="protein" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Food" positionX="-423.8203125" positionY="-101.4921875" width="128" height="90"/>
-        <element name="Nutrients" positionX="-54" positionY="9" width="128" height="90"/>
+        <element name="Food" positionX="-423.8203125" positionY="-101.4921875" width="128" height="88"/>
+        <element name="Nutrients" positionX="-54" positionY="9" width="128" height="103"/>
     </elements>
 </model>

--- a/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
+++ b/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
@@ -11,7 +11,7 @@
         <attribute name="protein" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Food" positionX="-63" positionY="-18" width="128" height="90"/>
+        <element name="Food" positionX="-423.8203125" positionY="-101.4921875" width="128" height="90"/>
         <element name="Nutrients" positionX="-54" positionY="9" width="128" height="90"/>
     </elements>
 </model>

--- a/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
+++ b/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18B75" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <elements/>
+    <entity name="Food" representedClassName="Food" syncable="YES" codeGenerationType="class">
+        <attribute name="brandName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="foodName" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="nutrients" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Nutrients" syncable="YES"/>
+    </entity>
+    <entity name="Nutrients" representedClassName="Nutrients" syncable="YES" codeGenerationType="class">
+        <attribute name="carbs" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="fat" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="protein" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="Food" positionX="-63" positionY="-18" width="128" height="90"/>
+        <element name="Nutrients" positionX="-54" positionY="9" width="128" height="90"/>
+    </elements>
 </model>

--- a/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
+++ b/GetFed/GetFed/GetFed.xcdatamodeld/GetFed.xcdatamodel/contents
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18B75" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Food" representedClassName="Food" syncable="YES">
-        <attribute name="brandName" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="foodName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="brand" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="nutrients" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Nutrients" syncable="YES"/>
     </entity>
     <entity name="Nutrients" representedClassName="Nutrients" syncable="YES">
@@ -12,7 +12,7 @@
         <attribute name="protein" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Food" positionX="-423.8203125" positionY="-101.4921875" width="128" height="88"/>
+        <element name="Food" positionX="-423.8203125" positionY="-101.4921875" width="128" height="90"/>
         <element name="Nutrients" positionX="-54" positionY="9" width="128" height="103"/>
     </elements>
 </model>

--- a/GetFed/GetFed/Helpers/APIClient.swift
+++ b/GetFed/GetFed/Helpers/APIClient.swift
@@ -8,12 +8,17 @@
 
 import Foundation
 import Alamofire
+import CoreData
 
 class APIClient {
     
     func parseData(_ data: Data) -> SearchResults? {
+        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return nil }
+        let context = appDelegate.persistentContainer.newBackgroundContext()
+        
         do {
             let decoder = JSONDecoder()
+            decoder.userInfo[CodingUserInfoKey.context!] = context
             let result = try decoder.decode(SearchResults.self, from: data)
             return result
         } catch {

--- a/GetFed/GetFed/Helpers/APIClient.swift
+++ b/GetFed/GetFed/Helpers/APIClient.swift
@@ -13,8 +13,8 @@ import CoreData
 class APIClient {
     
     func parseData(_ data: Data) -> SearchResults? {
-        guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return nil }
-        let context = appDelegate.persistentContainer.newBackgroundContext()
+        //guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else { return nil }
+        let context = CoreDataManager.sharedManager.persistentContainer.newBackgroundContext()
         
         do {
             let decoder = JSONDecoder()

--- a/GetFed/GetFed/Helpers/CoreDataManager.swift
+++ b/GetFed/GetFed/Helpers/CoreDataManager.swift
@@ -1,0 +1,41 @@
+//
+//  CoreDataManager.swift
+//  GetFed
+//
+//  Created by Britney Smith on 12/12/18.
+//  Copyright © 2018 Britney Smith. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+final class CoreDataManager/*: NSObject*/ {
+    
+    // MARK - Properties
+    static let sharedManager = CoreDataManager()
+    
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "GetFed")
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    private init() {}
+    
+    // MARK- Methods
+    func saveContext () {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+}

--- a/GetFed/GetFed/Helpers/CoreDataManager.swift
+++ b/GetFed/GetFed/Helpers/CoreDataManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 import CoreData
 
-final class CoreDataManager/*: NSObject*/ {
+final class CoreDataManager {
     
     // MARK - Properties
     static let sharedManager = CoreDataManager()

--- a/GetFed/GetFed/Helpers/CoreDataManager.swift
+++ b/GetFed/GetFed/Helpers/CoreDataManager.swift
@@ -25,6 +25,7 @@ final class CoreDataManager/*: NSObject*/ {
         })
         return container
     }()
+    var isSaved = false
     
     private init() {}
     
@@ -65,6 +66,24 @@ extension CoreDataManager {
         
         enteredFood.setValue(enteredNutrients, forKey: "nutrients")
         
-        
+        do {
+            try managedContext.save()
+            isSaved = true
+        } catch {
+            isSaved = false
+            print("Save error: \(error)")
+        }
+    }
+    
+    func fetchAllRecords() {
+        let foodFetch = NSFetchRequest<NSFetchRequestResult>(entityName: "Food")
+        do {
+            let records = try managedContext.fetch(foodFetch) as! [Food]
+            for record in records {
+                print("🍎 Food record: \(record.label), \(record.nutrients.calories)")
+            }
+        } catch {
+            print("Fetch error: \(error)")
+        }
     }
 }

--- a/GetFed/GetFed/Helpers/CoreDataManager.swift
+++ b/GetFed/GetFed/Helpers/CoreDataManager.swift
@@ -13,7 +13,9 @@ final class CoreDataManager/*: NSObject*/ {
     
     // MARK - Properties
     static let sharedManager = CoreDataManager()
-    
+    lazy var managedContext: NSManagedObjectContext = {
+        return CoreDataManager.sharedManager.persistentContainer.viewContext
+    }()
     lazy var persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "GetFed")
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
@@ -37,5 +39,32 @@ final class CoreDataManager/*: NSObject*/ {
                 fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
             }
         }
+    }
+}
+
+// MARK: Core Data Record Updates
+extension CoreDataManager {
+    
+    func insertNewFood(label: String, brand: String, calories: Double, protein: Double, carbs: Double, fat: Double) {
+        guard let foodEntity = NSEntityDescription.entity(forEntityName: "Food", in: managedContext) else { return }
+        guard let nutrientsEntity = NSEntityDescription.entity(forEntityName: "Nutrients", in: managedContext) else { return }
+        let enteredFood = NSManagedObject(entity: foodEntity, insertInto: managedContext)
+        let enteredNutrients = NSManagedObject(entity: nutrientsEntity, insertInto: managedContext)
+        let caloriesInt = Int(calories)
+        let proteinInt = Int(protein)
+        let carbsInt = Int(carbs)
+        let fatInt = Int(fat)
+        
+        enteredFood.setValue(label, forKey: "label")
+        enteredFood.setValue(brand, forKey: "brand")
+        
+        enteredNutrients.setValue(NSNumber(value: caloriesInt), forKey: "calories")
+        enteredNutrients.setValue(NSNumber(value: proteinInt), forKey: "protein")
+        enteredNutrients.setValue(NSNumber(value: carbsInt), forKey: "carbs")
+        enteredNutrients.setValue(NSNumber(value: fatInt), forKey: "fat")
+        
+        enteredFood.setValue(enteredNutrients, forKey: "nutrients")
+        
+        
     }
 }

--- a/GetFed/GetFed/Models/Food.swift
+++ b/GetFed/GetFed/Models/Food.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreData
 
 struct SearchResults: Decodable {
     let results: [FoodResults]
@@ -21,53 +22,53 @@ struct SearchResults: Decodable {
     }
 }
 
-struct FoodResults: Decodable {
-    let food: Food
+class FoodResults: NSManagedObject, Decodable {
+    let food: Food?
 }
-
-struct Food: Decodable {
-    let label: String
-    let nutrients: Nutrients
-    let category: String
-    let brand: String?
-    
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: FoodCodingKeys.self)
-        label = try container.decode(String.self, forKey: .label)
-        nutrients = try container.decode(Nutrients.self, forKey: .nutrients)
-        category = try container.decode(String.self, forKey: .category)
-        brand = try container.decodeIfPresent(String.self, forKey: .brand)
-    }
-    
-    enum FoodCodingKeys: CodingKey {
-        case label
-        case nutrients
-        case category
-        case brand
-    }
-}
-
-struct Nutrients: Decodable {
-    let calories: Double?
-    let protein: Double?
-    let fat: Double?
-    let carbs: Double?
-    
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: NutrientsCodingKeys.self)
-        calories = try container.decodeIfPresent(Double.self, forKey: .calories)
-        protein = try container.decodeIfPresent(Double.self, forKey: .protein)
-        fat = try container.decodeIfPresent(Double.self, forKey: .fat)
-        carbs = try container.decodeIfPresent(Double.self, forKey: .carbs)
-    }
-    
-    enum NutrientsCodingKeys: String, CodingKey {
-        case calories = "ENERC_KCAL"
-        case protein = "PROCNT"
-        case fat = "FAT"
-        case carbs = "CHOCDF"
-    }
-}
+//
+//struct Food: Decodable {
+//    let label: String
+//    let nutrients: Nutrients
+//    let category: String
+//    let brand: String?
+//
+//    init(from decoder: Decoder) throws {
+//        let container = try decoder.container(keyedBy: FoodCodingKeys.self)
+//        label = try container.decode(String.self, forKey: .label)
+//        nutrients = try container.decode(Nutrients.self, forKey: .nutrients)
+//        category = try container.decode(String.self, forKey: .category)
+//        brand = try container.decodeIfPresent(String.self, forKey: .brand)
+//    }
+//
+//    enum FoodCodingKeys: CodingKey {
+//        case label
+//        case nutrients
+//        case category
+//        case brand
+//    }
+//}
+//
+//class Nutrients: NSManagedObject, Decodable {
+//    @NSManaged var calories: Double?
+//    let protein: Double?
+//    let fat: Double?
+//    let carbs: Double?
+//
+//    init(from decoder: Decoder) throws {
+//        let container = try decoder.container(keyedBy: NutrientsCodingKeys.self)
+//        calories = try container.decodeIfPresent(Double.self, forKey: .calories)
+//        protein = try container.decodeIfPresent(Double.self, forKey: .protein)
+//        fat = try container.decodeIfPresent(Double.self, forKey: .fat)
+//        carbs = try container.decodeIfPresent(Double.self, forKey: .carbs)
+//    }
+//
+//    enum NutrientsCodingKeys: String, CodingKey {
+//        case calories = "ENERC_KCAL"
+//        case protein = "PROCNT"
+//        case fat = "FAT"
+//        case carbs = "CHOCDF"
+//    }
+//}
 
 let sampleURL = "https://api.edamam.com/api/food-database/parser?ingr=red%20apple&app_id={your app_id}&app_key={your app_key}"
 

--- a/GetFed/Podfile.lock
+++ b/GetFed/Podfile.lock
@@ -1,0 +1,22 @@
+PODS:
+  - Alamofire (4.8.0)
+  - Charts (3.2.1):
+    - Charts/Core (= 3.2.1)
+  - Charts/Core (3.2.1)
+
+DEPENDENCIES:
+  - Alamofire (~> 4.7)
+  - Charts
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Charts
+
+SPEC CHECKSUMS:
+  Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
+  Charts: f122fb70b19847fa5817d018b77d6c5a2296ab25
+
+PODFILE CHECKSUM: 3fddd59faca275bd521f398406b514df91bba046
+
+COCOAPODS: 1.5.3


### PR DESCRIPTION
## What you did :question:
- Added Core Data functionality so that custom user food entries are saved in Core Data's SQLite database
- Added alerts for both successful and failing saves

## How you did it :white_check_mark:
- Created managedContext object to hold values for Core Data Entities
- Saved the entries for the fields in the Food Entry view to the appropriate entities, Food and Nutrients, and linked the entities (one-to-one relationship); method is called upon tapping 'Save'
- Wrote method to clear textfields upon successful save
- Wrote methods to call alerts for successful and failed saves
- Added temporary method `readRecords()` to display all current records in the data store (to test the save feature)


## How to test it :microscope:
- Run the app
- Tap 'Food Entry'
- Enter values in the Food Entry's fields
- Tap 'Save'
- Note that a success alert message is displayed, and the message includes the name of the food entry
- Note that in the Terminal, the values of the new food entry (starts with 🍞) and the current contents of the data store (starts with 🍎) are displayed. The new food entry should appear at the end of the 🍎list


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2018-12-11 at 11 18 09](https://user-images.githubusercontent.com/8409475/49822613-9a6cdb80-fd4b-11e8-957e-125dfeb1841e.png)
![simulator screen shot - iphone xr - 2018-12-11 at 11 18 17](https://user-images.githubusercontent.com/8409475/49822619-a3f64380-fd4b-11e8-9291-9e1615557bdd.png)
![simulator screen shot - iphone xr - 2018-12-11 at 11 18 23](https://user-images.githubusercontent.com/8409475/49822661-be302180-fd4b-11e8-91f1-6e2ab9697983.png)
![screen shot 2018-12-11 at 1 53 00 pm](https://user-images.githubusercontent.com/8409475/49822806-267f0300-fd4c-11e8-967c-22a17186dcd7.png)

