### PR TITLE
Resolved autolayout warnings

### DIFF
--- a/GetFed/GetFed/Views/FoodResultTableViewCell.xib
+++ b/GetFed/GetFed/Views/FoodResultTableViewCell.xib
@@ -30,7 +30,7 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="Ohe-X7-kog">
-                                <rect key="frame" x="50" y="0.0" width="270" height="60"/>
+                                <rect key="frame" x="30" y="0.0" width="290" height="60"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="foodLabel" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vrO-w4-0W9">
                                         <rect key="frame" x="0.0" y="0.0" width="82" height="30"/>
@@ -48,7 +48,7 @@
                             </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="Ohe-X7-kog" firstAttribute="leading" secondItem="dGK-WW-5Ts" secondAttribute="trailing" constant="20" id="80l-3A-wfA"/>
+                            <constraint firstItem="Ohe-X7-kog" firstAttribute="leading" secondItem="dGK-WW-5Ts" secondAttribute="trailing" id="80l-3A-wfA"/>
                             <constraint firstAttribute="trailing" secondItem="Ohe-X7-kog" secondAttribute="trailing" id="OBi-pj-dGC"/>
                             <constraint firstAttribute="bottom" secondItem="dGK-WW-5Ts" secondAttribute="bottom" id="R0c-oZ-Z9C"/>
                             <constraint firstItem="dGK-WW-5Ts" firstAttribute="top" secondItem="n5S-RF-kbq" secondAttribute="top" id="qdU-uu-KiO"/>


### PR DESCRIPTION
## What you did :question:
- Resolved Auto Layout warnings in Food Search View
- No functionality change

## How you did it :white_check_mark:
- Set constant of conflicting constraint to 0


## How to test it :microscope:
- Run the app
- If there are no custom food entries in your instance of the app, enter one ('Food Entry '> complete fields > 'Save' > 'OK' > 'Back')
- Tap 'Food Search'
- Note that when any custom entries are displayed, no Auto Layout warnings are printed to the terminal (see screenshot)


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2019-01-10 at 15 23 14](https://user-images.githubusercontent.com/8409475/50995372-efd40e00-14ec-11e9-99ef-f990ebe60705.png)
![screen shot 2019-01-10 at 3 23 38 pm](https://user-images.githubusercontent.com/8409475/50995389-f95d7600-14ec-11e9-8ce2-1cd0b4a52791.png)
