### PR TITLE
Constants change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,3 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 
 .DS_Store
-Constants.swift

--- a/GetFed/GetFed/Helpers/Constants.swift
+++ b/GetFed/GetFed/Helpers/Constants.swift
@@ -1,0 +1,13 @@
+//
+//  Constants.swift
+//  GetFed
+//
+//  Created by Britney Smith on 12/10/18.
+//  Copyright © 2018 Britney Smith. All rights reserved.
+//
+
+import Foundation
+
+/// Replace with app key and app id from developer account (for the Food API) at https://www.edamam.com
+let EdamamAppID = "<#your-app-id#>"
+let EdamamAppKey = "<#your-app-key#>"

--- a/README.md
+++ b/README.md
@@ -4,14 +4,12 @@
 ## Project Setup
 
 - After cloning, navigate to directory `GetFed/GetFed` and run `pod install`
-- Remove old 'Constants.swift' file in 'Helpers' directory of the project (it appears in red in XCode).
 
 ## Opening the project and running the app
 
-- Open a free developer account (for the Food API) at https://www.edamam.com
+- Open a free developer account (for the **Food API**) at https://www.edamam.com
 - In XCode, open the `GetFed.xcworkspace` file
-- In the `Constants-example.swift` file, replace the values for `EdamamAppID` and `EdamamAppKey` with those provided with the Edamam developer account, found in the Dashboard. The Application ID and Application Key that come with the initial 'API Signup' sample app should be fine to use.
-- Change the name of this file to `Constants.swift`
+- In the `Constants.swift` file, replace the string values for `EdamamAppID` and `EdamamAppKey` with those provided with the Edamam developer account, found in the Dashboard. The Application ID and Application Key that come with the initial 'API Signup' sample app should be fine to use.
 - App should be ready to run!
 
 ## Credits


### PR DESCRIPTION
## What you did :question:
- Changed the setup process the app
- Updated documentation

## How you did it :white_check_mark:
- Added placeholder for `EdamamAppID` and `EdamamAppKey` constants
- Removed references to `Constants-example.swift` from README
- Removed references to removing `Constants.swift` from README
- Removed `Constants.swift` from gitignore


## How to test it :microscope:
- Note that `Constants.swift` file contains placeholder text for `EdamamAppID` and `EdamamAppKey` constants



## Screenshots (if applicable) :camera:
![screen shot 2019-01-11 at 1 51 05 pm](https://user-images.githubusercontent.com/8409475/51053554-fa071280-15a7-11e9-8bb7-ffc796fc36d4.png)
