### PR TITLE
Refactor parse method and fetch method to return generic type

### DIFF
--- a/GetFed/GetFed/Helpers/APIClient.swift
+++ b/GetFed/GetFed/Helpers/APIClient.swift
@@ -31,13 +31,13 @@ final class APIClient {
         return url
     }
     
-    func parseData(_ data: Data) -> SearchResults? {
+    func parse<T: Decodable>(_ data: Data) -> T? {
         let context = CoreDataManager.sharedManager.persistentContainer.newBackgroundContext()
         
         do {
             let decoder = JSONDecoder()
             decoder.userInfo[CodingUserInfoKey.context!] = context
-            let result = try decoder.decode(SearchResults.self, from: data)
+            let result = try decoder.decode(T.self, from: data)
             return result
         } catch {
             print("Error in parsing: \(error)")
@@ -45,7 +45,7 @@ final class APIClient {
         }
     }
     
-    func fetchData(url: URL, queue: DispatchQueue = .main, completion: @escaping (SearchResults) -> ()) {
+    func fetchData<T: Decodable>(url: URL, queue: DispatchQueue = .main, completion: @escaping (T) -> ()) {
         Alamofire.request(url).validate().responseData { response in
             switch response.result {
             case .success:
@@ -55,7 +55,7 @@ final class APIClient {
             }
             
             if let data = response.result.value {
-                guard let result = self.parseData(data) else { return }
+                guard let result: T = self.parse(data) else { return }
                 queue.async { completion(result) }
             }
         }


### PR DESCRIPTION
## What you did :question:
- Refactored both `parse()` and `fetchData()` methods to return generic types
- No app functionality change

## How you did it :white_check_mark:
- Added generic type `T` to function signatures
- Added generic type `T` to `JSONDecoder.decode(Type, from:_)` argument
- Explicitly declared `result` to be of type `T` in `fetchData()` method


## How to test it :microscope:
- **Note: this test requires an appID and appKey**
- Run the app
- Tap 'Food Search'
- Search for any food
- Note that results are returned and populated in table view


## Screenshots (if applicable) :camera:
![simulator screen shot - iphone xr - 2019-01-25 at 10 10 11](https://user-images.githubusercontent.com/8409475/51754691-f769ea00-208a-11e9-8494-73d41890a085.png)
